### PR TITLE
Revamp chat-style estimator experience and backend handling

### DIFF
--- a/apps_script.gs
+++ b/apps_script.gs
@@ -1,63 +1,271 @@
-// Google Apps Script backend for MFTNB
-// HOW TO USE:
-// 1) In Google Drive: New -> Google Sheet (name it MFTNB Leads). Keep Sheet1.
-// 2) Extensions -> Apps Script. Paste this code. File -> Save.
-// 3) Deploy -> New deployment -> Type: Web app. Execute as: Me. Access: Anyone (or Anyone with the link).
-// 4) Copy the Web app URL and paste it into index.html BACKEND.appsScriptUrl.
+// Google Apps Script backend for Moving Forward to New Beginnings
+// Handles chat-style estimate submissions and quick contact messages.
 
-const SHEET_NAME = 'Sheet1';
-const SEND_TO = 'info@mftnb.ca';
-const SUBJECT = 'New MFTNB Estimate Request';
+const ESTIMATE_SHEET_NAME = 'Leads';
+const QUICK_SHEET_NAME = 'Quick Messages';
+const OFFICE_EMAIL = 'info@mftnb.ca';
+const CUSTOMER_SUBJECT = 'We received your message – Moving Forward to New Beginnings';
+const TURNSTILE_SECRET = '0x4AAAAAAB2gwLfn0PN8o6zw4eLmMN0r49g';
 
-function doOptions(e) {
-  return ContentService.createTextOutput('')
-    .setMimeType(ContentService.MimeType.TEXT)
-    .setHeaders({
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'POST, OPTIONS, GET',
-      'Access-Control-Allow-Headers': 'Content-Type',
-    });
+function doOptions() {
+  return respond({ ok: true }, 200);
+}
+
+function doGet() {
+  return respond({ ok: true, service: 'mftnb-apps-script' });
 }
 
 function doPost(e) {
   try {
-    const body = JSON.parse(e.postData.contents || '{}');
-    if (body.honeypot === true) return respond({ ok: true, skipped: true, reason: 'honeypot' });
+    if (!e || !e.postData || !e.postData.contents) {
+      throw new Error('Missing request body');
+    }
+    const body = JSON.parse(e.postData.contents);
+    const formType = body.formType;
+    if (!formType) throw new Error('Missing formType');
+    const token = body.turnstileToken;
+    const expectedAction = formType === 'estimate' ? 'estimate' : (formType === 'quick-message' ? 'quick_message' : '');
+    const verification = verifyTurnstile(token, e, expectedAction);
+    if (!verification.success) {
+      return respond({ ok: false, error: 'Human verification failed.' }, 400);
+    }
 
-    const ss = SpreadsheetApp.getActiveSpreadsheet().getSheetByName(SHEET_NAME);
-    if (!ss) throw new Error('Sheet not found');
+    if (formType === 'estimate') {
+      const record = handleEstimateSubmission(body);
+      return respond({ ok: true, row: record.rowNumber });
+    }
 
-    const fields = [
-      'submittedAt','name','email','phone','pickup','dropoff','moveDate','timeWindow',
-      'homeSize','access','inventory','extras','notes','source'
-    ];
-    const row = fields.map(k => {
-      const v = body[k];
-      if (k === 'inventory' || k === 'extras') return JSON.stringify(v || {});
-      return v || '';
-    });
-    ss.appendRow(row);
+    if (formType === 'quick-message') {
+      handleQuickMessageSubmission(body);
+      return respond({ ok: true });
+    }
 
-    try {
-      MailApp.sendEmail({ to: SEND_TO, subject: SUBJECT, htmlBody: '<pre>' + JSON.stringify(body, null, 2) + '</pre>' });
-    } catch (err) { /* ignore mail failures on locked accounts */ }
-
-    return respond({ ok: true });
+    throw new Error('Unsupported formType');
   } catch (err) {
-    return respond({ ok: false, error: String(err) }, 500);
+    console.error('Error in doPost', err);
+    return respond({ ok: false, error: err.message || String(err) }, 500);
   }
 }
 
-function doGet(e) {
-  return respond({ ok: true, service: 'mftnb-apps-script' });
+function handleEstimateSubmission(body) {
+  const requiredFields = ['name', 'email', 'phone', 'pickup', 'dropoff'];
+  requiredFields.forEach(field => {
+    if (!body[field]) {
+      throw new Error('Missing required field: ' + field);
+    }
+  });
+
+  const sheet = getOrCreateSheet(ESTIMATE_SHEET_NAME);
+  const timestamp = new Date();
+  const extras = Array.isArray(body.extras) ? body.extras.join(', ') : '';
+  const row = [
+    timestamp,
+    body.name || '',
+    body.email || '',
+    body.phone || '',
+    body.pickup || '',
+    body.dropoff || '',
+    body.moveDate || '',
+    body.timeWindow || '',
+    body.homeType || body.homeSize || '',
+    body.bedrooms || '',
+    body.access || '',
+    body.inventory || '',
+    extras,
+    body.notes || '',
+    body.source || '',
+    body.consent === true ? 'Yes' : 'No'
+  ];
+  sheet.appendRow(row);
+  const rowNumber = sheet.getLastRow();
+
+  const officeHtml = buildEstimateHtml(body, timestamp, rowNumber);
+  try {
+    MailApp.sendEmail({
+      to: OFFICE_EMAIL,
+      subject: `New moving estimate from ${body.name}`,
+      htmlBody: officeHtml
+    });
+  } catch (err) {
+    console.error('Unable to email office copy', err);
+  }
+
+  if (body.email) {
+    const customerHtml = buildCustomerEstimateHtml(body, timestamp);
+    try {
+      MailApp.sendEmail({
+        to: body.email,
+        subject: 'Thanks for reaching out to Moving Forward to New Beginnings',
+        htmlBody: customerHtml,
+        replyTo: OFFICE_EMAIL
+      });
+    } catch (err) {
+      console.error('Unable to send customer confirmation', err);
+    }
+  }
+
+  return { rowNumber };
+}
+
+function handleQuickMessageSubmission(body) {
+  if (!body.name) throw new Error('Missing name');
+  if (!body.message) throw new Error('Missing message');
+
+  const sheet = getOrCreateSheet(QUICK_SHEET_NAME);
+  const timestamp = new Date();
+  sheet.appendRow([
+    timestamp,
+    body.name || '',
+    body.email || '',
+    body.phone || '',
+    body.message || '',
+    body.source || ''
+  ]);
+
+  const officeBody = `
+    <p><strong>New quick message received:</strong></p>
+    <ul>
+      <li><strong>Name:</strong> ${sanitize(body.name)}</li>
+      <li><strong>Email:</strong> ${sanitize(body.email || 'N/A')}</li>
+      <li><strong>Phone:</strong> ${sanitize(body.phone || 'N/A')}</li>
+      <li><strong>Message:</strong><br />${sanitize(body.message).replace(/\n/g, '<br />')}</li>
+    </ul>
+  `;
+
+  try {
+    MailApp.sendEmail({
+      to: OFFICE_EMAIL,
+      subject: `Quick message from ${body.name}`,
+      htmlBody: officeBody
+    });
+  } catch (err) {
+    console.error('Unable to email quick message', err);
+  }
+
+  if (body.email) {
+    const customerBody = `
+      <p>Hi ${sanitize(body.name)},</p>
+      <p>Thanks for getting in touch with Moving Forward to New Beginnings. We received your note and will reply shortly.</p>
+      <p><strong>Your message:</strong><br />${sanitize(body.message).replace(/\n/g, '<br />')}</p>
+      <p>If anything changes, call or text us at <a href="tel:+15877310695">(587) 731-0695</a>.</p>
+      <p>— Chris Ehret &amp; the MFTNB team</p>
+    `;
+    try {
+      MailApp.sendEmail({
+        to: body.email,
+        subject: CUSTOMER_SUBJECT,
+        htmlBody: customerBody,
+        replyTo: OFFICE_EMAIL
+      });
+    } catch (err) {
+      console.error('Unable to send quick message confirmation', err);
+    }
+  }
+}
+
+function verifyTurnstile(token, e, expectedAction) {
+  if (!token) {
+    return { success: false };
+  }
+  const remoteip = e && e.context ? e.context.clientIp : '';
+  const payload = {
+    secret: TURNSTILE_SECRET,
+    response: token
+  };
+  if (remoteip) {
+    payload.remoteip = remoteip;
+  }
+  const response = UrlFetchApp.fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+    method: 'post',
+    payload,
+    muteHttpExceptions: true
+  });
+  const data = JSON.parse(response.getContentText() || '{}');
+  if (!data.success) {
+    console.error('Turnstile verification failed', data['error-codes']);
+    return { success: false };
+  }
+  if (expectedAction && data.action && data.action !== expectedAction) {
+    console.warn('Unexpected Turnstile action', data.action, 'expected', expectedAction);
+  }
+  return data;
+}
+
+function buildEstimateHtml(body, timestamp, rowNumber) {
+  const extras = Array.isArray(body.extras) && body.extras.length ? body.extras.join(', ') : 'None';
+  return `
+    <h2>New moving estimate (row ${rowNumber})</h2>
+    <p><strong>Received:</strong> ${timestamp}</p>
+    <table border="0" cellpadding="6" cellspacing="0" style="border-collapse:collapse;">
+      <tbody>
+        <tr><td><strong>Name</strong></td><td>${sanitize(body.name)}</td></tr>
+        <tr><td><strong>Email</strong></td><td>${sanitize(body.email)}</td></tr>
+        <tr><td><strong>Phone</strong></td><td>${sanitize(body.phone)}</td></tr>
+        <tr><td><strong>Moving from</strong></td><td>${sanitize(body.pickup)}</td></tr>
+        <tr><td><strong>Moving to</strong></td><td>${sanitize(body.dropoff)}</td></tr>
+        <tr><td><strong>Move date</strong></td><td>${sanitize(body.moveDate || 'Flexible')}</td></tr>
+        <tr><td><strong>Preferred time</strong></td><td>${sanitize(body.timeWindow || 'Flexible')}</td></tr>
+        <tr><td><strong>Home type</strong></td><td>${sanitize(body.homeType || body.homeSize || '')}</td></tr>
+        <tr><td><strong>Bedrooms</strong></td><td>${sanitize(body.bedrooms || '')}</td></tr>
+        <tr><td><strong>Access details</strong></td><td>${sanitize(body.access || '')}</td></tr>
+        <tr><td><strong>Special items</strong></td><td>${sanitize(body.inventory || '')}</td></tr>
+        <tr><td><strong>Extras</strong></td><td>${sanitize(extras)}</td></tr>
+        <tr><td><strong>Notes</strong></td><td>${sanitize(body.notes || '')}</td></tr>
+        <tr><td><strong>Source</strong></td><td>${sanitize(body.source || '')}</td></tr>
+      </tbody>
+    </table>
+  `;
+}
+
+function buildCustomerEstimateHtml(body, timestamp) {
+  const extras = Array.isArray(body.extras) && body.extras.length ? body.extras.join(', ') : 'None';
+  return `
+    <p>Hi ${sanitize(body.name)},</p>
+    <p>Thank you for reaching out to Moving Forward to New Beginnings. We received your moving details on <strong>${timestamp.toLocaleString()}</strong> and will follow up shortly with next steps.</p>
+    <h3>Your summary</h3>
+    <ul>
+      <li><strong>Move date:</strong> ${sanitize(body.moveDate || 'Flexible')}</li>
+      <li><strong>From:</strong> ${sanitize(body.pickup)}</li>
+      <li><strong>To:</strong> ${sanitize(body.dropoff)}</li>
+      <li><strong>Home type &amp; rooms:</strong> ${sanitize([body.homeType || body.homeSize || '', body.bedrooms || ''].filter(Boolean).join(' · ') || 'Details pending')}</li>
+      <li><strong>Access details:</strong> ${sanitize(body.access || 'Provided verbally')}</li>
+      <li><strong>Special items:</strong> ${sanitize(body.inventory || 'None noted')}</li>
+      <li><strong>Extra services:</strong> ${sanitize(extras)}</li>
+      <li><strong>Additional notes:</strong> ${sanitize(body.notes || 'None')}</li>
+    </ul>
+    <p>If anything changes, reply to this email or call/text <a href="tel:+15877310695">(587) 731-0695</a>.</p>
+    <p>With gratitude,<br />Chris Ehret &amp; the MFTNB team</p>
+  `;
+}
+
+function getOrCreateSheet(name) {
+  const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = spreadsheet.getSheetByName(name);
+  if (!sheet) {
+    sheet = spreadsheet.insertSheet(name);
+  }
+  return sheet;
+}
+
+function sanitize(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 function respond(obj, code) {
-  const out = ContentService.createTextOutput(JSON.stringify(obj)).setMimeType(ContentService.MimeType.JSON);
-  out.setHeaders({
+  const output = ContentService.createTextOutput(JSON.stringify(obj)).setMimeType(ContentService.MimeType.JSON);
+  output.setHeaders({
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'POST, OPTIONS, GET',
-    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Headers': 'Content-Type'
   });
-  return out;
+  if (typeof code === 'number') {
+    output.setResponseCode(code);
+  }
+  return output;
 }

--- a/index.html
+++ b/index.html
@@ -3,40 +3,19 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Moving Forward to New Beginnings | Red Deer Movers</title>
-  <meta name="description" content="Professional moving services in Red Deer and surrounding areas. Local & long-distance moves, packing, loading, unloading, and more. Free estimates." />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="icon" type="image/png" href="logo.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png">
-  <link rel="icon" type="image/png" sizes="64x64" href="favicon-64.png">
-  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-  <link rel="shortcut icon" href="favicon.ico">
-  <meta name="theme-color" content="#992e34">
-  <script defer src="https://challenges.cloudflare.com/turnstile/v0/api.js"></script>
-  <style>
-    :root{ --brand-50:#f0e0e1; --brand-100:#e0c0c2; --brand-600:#b8373e; --brand-700:#992e34; --brand-800:#6b2024; --brand-900:#54191d; }
-    /* smooth scrolling + anchor offset so the step bar is fully visible */
-  html { scroll-behavior: smooth; }                 /* NEW */
-  section[id] { scroll-margin-top: 96px; }          /* NEW */
-
-  .caret { width: 1px; background: currentColor; display:inline-block; animation: blink 1s step-end infinite; }
-  @keyframes blink { 50% { opacity: 0; } }
-  ... .caret { width: 1px; background: currentColor; display:inline-block; animation: blink 1s step-end infinite; }
-    @keyframes blink { 50% { opacity: 0; } }
-    input[type=number]::-webkit-inner-spin-button,
-    input[type=number]::-webkit-outer-spin-button { -webkit-appearance: none; margin: 0; }
-    .fade-in { animation: fade 300ms ease-out; }
-    @keyframes fade { from { opacity: 0; transform: translateY(4px) } to { opacity: 1; transform:none } }
-    // After DOM loads, if the URL already has #estimator, nudge scroll to show the full bar
-  window.addEventListener('load', () => {
-    if (location.hash === '#estimator') {
-      const el = document.querySelector('#estimator');
-      if (el) setTimeout(() => el.scrollIntoView({behavior:'instant', block:'start'}), 50);
-    }
-  });
-  </style>
-  <script type="application/ld+json" id="org-jsonld">
+  <title>Moving Forward to New Beginnings | Compassionate Movers in Red Deer</title>
+  <meta name="description" content="Moving Forward to New Beginnings delivers caring moving services across Red Deer and Central Alberta. Start a guided chat-style estimate, read testimonials, and discover our community rescue moves." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="64x64" href="favicon-64.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+  <link rel="shortcut icon" href="favicon.ico" />
+  <meta name="theme-color" content="#142645" />
+  <script defer src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onTurnstileLibraryLoad" async></script>
+  <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "MovingCompany",
@@ -54,295 +33,309 @@
   }
   </script>
 </head>
-<body class="bg-zinc-50 text-zinc-900">
-  <header class="bg-zinc-900 text-white">
-    <div class="max-w-6xl mx-auto px-4 py-2 flex items-center justify-between">
-      <div class="flex items-center gap-3">
-        <img src="logo.png" alt="Moving Forward to New Beginnings logo" class="h-10 w-auto select-none" onerror="this.onerror=null;this.src='data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27200%27%20height%3D%2748%27%3E%3Ctext%20x%3D%270%27%20y%3D%2736%27%20font-family%3D%27Inter%2C%20system-ui%2C%20Arial%27%20font-size%3D%2736%27%20font-weight%3D%27700%27%20fill%3D%27%23992e34%27%3EMFTNB%3C/text%3E%3C/svg%3E';">
-        <span class="font-semibold tracking-wide">Moving Forward to New Beginnings</span>
-      </div>
-      <nav class="hidden sm:flex items-center gap-6 text-sm">
-        <a href="#services" class="hover:underline">Services</a>
-        <a href="#estimator" class="hover:underline">Get Estimate</a>
-        <a href="#contact" class="hover:underline">Contact</a>
+<body>
+  <header class="site-header">
+    <div class="inner">
+      <a href="#top" class="brand" aria-label="Moving Forward to New Beginnings home">
+        <img src="logo.png" alt="Moving Forward to New Beginnings logo" />
+        <span>Moving Forward to New Beginnings</span>
+      </a>
+      <nav class="primary-nav" aria-label="Primary">
+        <a href="#services">Services</a>
+        <a href="#community">Community</a>
+        <a href="#estimator">Estimator</a>
+        <a href="#testimonials">Testimonials</a>
+        <a href="#contact">Contact</a>
       </nav>
-      <div class="flex items-center gap-4">
-        <a id="topPhone" href="tel:+15877310695" class="text-sm underline decoration-white/30 underline-offset-4">(587) 731-0695</a>
-        <a id="topEmail" href="mailto:info@mftnb.ca" class="hidden md:inline text-sm underline decoration-white/30 underline-offset-4">info@mftnb.ca</a>
+      <div class="header-cta">
+        <a href="tel:+15877310695">Call (587) 731-0695</a>
+        <a href="mailto:info@mftnb.ca">info@mftnb.ca</a>
       </div>
     </div>
   </header>
 
-  <section class="bg-gradient-to-b from-white to-zinc-100">
-    <div class="max-w-6xl mx-auto px-4 py-16 grid lg:grid-cols-2 gap-8 items-center">
-      <div>
-        <h1 class="text-3xl sm:text-4xl md:text-5xl font-extrabold leading-tight">Reliable movers for Red Deer & surrounding areas</h1>
-        <p class="mt-4 text-zinc-600 text-lg">Local and long-distance moving, packing, loading and unloading—done with care so you can focus on your new beginning.</p>
-        <div class="mt-6 flex flex-wrap gap-3">
-          <a href="#estimator" class="px-5 py-3 rounded-xl bg-[var(--brand-700)] text-white font-medium hover:bg-[var(--brand-800)]">Get a Free Estimate</a>
-          <a href="#services" class="px-5 py-3 rounded-xl bg-white border border-zinc-200 font-medium hover:bg-zinc-50">See Services</a>
-        </div>
-        <div class="mt-6 text-sm text-zinc-500">Open Mon–Fri 9–6, Sat 10–2 · Fully insured · Friendly crews</div>
-      </div>
-      <div class="relative">
-        <div class="aspect-video w-full rounded-2xl bg-white shadow ring-1 ring-zinc-200 grid place-items-center">
-          <div class="text-center p-6">
-            <div class="text-xl font-semibold">Free Chat-Style Estimate</div>
-            <p class="mt-2 text-zinc-600">Walk through your home room-by-room, list items, and pick your move date. Save progress and submit in minutes.</p>
+  <main id="top">
+    <section class="hero">
+      <div class="container hero-grid">
+        <div>
+          <h1>Moves powered by compassion, safety, and experience.</h1>
+          <p>We guide you through every step—whether you are downsizing, moving across town, or rebuilding after a difficult season. Our friendly crews handle the heavy lifting while you focus on your new beginning.</p>
+          <div class="hero-actions">
+            <a class="btn-primary" href="#estimator">Start your estimate</a>
+            <a class="btn-secondary" href="tel:+15877310695">Talk to a move coordinator</a>
           </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section id="services" class="py-14">
-    <div class="max-w-6xl mx-auto px-4">
-      <h2 class="text-2xl font-bold">Services</h2>
-      <div class="mt-6 grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        <article class="p-5 bg-white rounded-2xl border border-zinc-200 shadow-sm">
-          <h3 class="font-semibold">Residential Moving</h3>
-          <p class="text-sm text-zinc-600 mt-1">Apartments, condos, houses. Careful packing, loading, transport, and setup.</p>
-        </article>
-        <article class="p-5 bg-white rounded-2xl border border-zinc-200 shadow-sm">
-          <h3 class="font-semibold">Long-Distance & Local</h3>
-          <p class="text-sm text-zinc-600 mt-1">Whether you’re moving across town or across Alberta, we’ll get you there.</p>
-        </article>
-        <article class="p-5 bg-white rounded-2xl border border-zinc-200 shadow-sm">
-          <h3 class="font-semibold">Packing & Supplies</h3>
-          <p class="text-sm text-zinc-600 mt-1">Full or partial packing, boxes and materials available on request.</p>
-        </article>
-        <article class="p-5 bg-white rounded-2xl border border-zinc-200 shadow-sm">
-          <h3 class="font-semibold">Loading / Unloading</h3>
-          <p class="text-sm text-zinc-600 mt-1">Truck, pod, or storage—hire us to load or unload professionally.</p>
-        </article>
-        <article class="p-5 bg-white rounded-2xl border border-zinc-200 shadow-sm">
-          <h3 class="font-semibold">Specialty Items</h3>
-          <p class="text-sm text-zinc-600 mt-1">Large or fragile items (e.g., pianos, safes). We’ll plan it properly.</p>
-        </article>
-        <article class="p-5 bg-white rounded-2xl border border-zinc-200 shadow-sm">
-          <h3 class="font-semibold">Clean-outs & Junk Removal</h3>
-          <p class="text-sm text-zinc-600 mt-1">Optional add-on to leave your place broom-clean.</p>
-        </article>
-      </div>
-    </div>
-  </section>
-
-  <section id="estimator" class="py-14 bg-white">
-    <div class="max-w-6xl mx-auto px-4">
-      <div class="flex items-center justify-between gap-4">
-        <h2 class="text-2xl font-bold">Chat-Style Moving Estimate</h2>
-        <div class="text-sm text-zinc-600">Your info is saved to this device and only submitted when you press <span class="font-medium">Send</span>.</div>
-      </div>
-
-      <ol id="stepper" class="mt-4 flex flex-wrap items-center gap-2 text-xs text-zinc-600">
-        <li class="px-2 py-1 rounded bg-zinc-100" data-step="1">Contact</li>
-        <li class="px-2 py-1 rounded bg-zinc-100" data-step="2">Addresses</li>
-        <li class="px-2 py-1 rounded bg-zinc-100" data-step="3">Date/Time</li>
-        <li class="px-2 py-1 rounded bg-zinc-100" data-step="4">Home & Access</li>
-        <li class="px-2 py-1 rounded bg-zinc-100" data-step="5">Inventory</li>
-        <li class="px-2 py-1 rounded bg-zinc-100" data-step="6">Extras</li>
-        <li class="px-2 py-1 rounded bg-zinc-100" data-step="7">Review</li>
-      </ol>
-
-      <div class="mt-2 w-full bg-zinc-100 rounded-full h-2">
-        <div id="progressBar" class="h-2 bg-[var(--brand-700)] rounded-full" style="width:0%"></div>
-      </div>
-      <div class="mt-2 text-xs text-zinc-500"><span id="stepLabel">Step 1 of 13</span></div>
-
-      <div class="mt-6 grid lg:grid-cols-2 gap-6">
-        <div class="rounded-2xl border border-zinc-200 shadow-sm overflow-hidden bg-zinc-50">
-          <div id="chat" class="h-[58dvh] md:h-[520px] overflow-y-auto p-4 space-y-3 text-sm"></div>
-          <div id="composer" class="border-t border-zinc-200 bg-white p-3 pb-[max(env(safe-area-inset-bottom),0px)]">
-            <div id="currentPrompt" class="text-xs text-zinc-600 mb-1 max-h-12 overflow-hidden"></div>
-            <div class="flex gap-2">
-              <input id="chatInput" class="flex-1 px-3 py-2 rounded-lg border border-zinc-300 focus:outline-none focus:ring-2 focus:ring-[var(--brand-700)]" placeholder="Type your answer and press Enter…" />
-              <button id="chatNext" class="px-4 py-2 rounded-lg bg-[var(--brand-700)] hover:bg-[var(--brand-800)] text-white disabled:opacity-50 disabled:cursor-not-allowed"><span id="nextLabel">Start</span></button>
+          <div class="badge-row">
+            <div class="badge">
+              Serving Red Deer &amp; Central Alberta
+              <span>Trusted for more than a decade</span>
+            </div>
+            <div class="badge">
+              Community rescue moves
+              <span>Supporting families fleeing violence</span>
+            </div>
+            <div class="badge">
+              Caring crews &amp; clear updates
+              <span>Friendly for seniors &amp; first-time movers</span>
             </div>
           </div>
         </div>
+        <div class="hero-visual">
+          <div class="hero-card">
+            <h3>What you get with our guided chat</h3>
+            <ul>
+              <li>One question at a time—easy to follow</li>
+              <li>Progress saved securely on your device</li>
+              <li>Submit in minutes with human verification</li>
+              <li>Instant email confirmation of your request</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
 
-        <aside class="rounded-2xl border border-zinc-200 shadow-sm bg-white p-4 space-y-4">
-          <h3 class="font-semibold">Your estimate</h3>
-          <div id="summaryCards" class="grid gap-3 text-sm"></div>
-          <div class="flex items-start gap-2 text-sm">
-            <input id="consent" type="checkbox" class="mt-1">
-            <label for="consent" class="text-zinc-600">I agree to the <a href="#" id="openPolicy" class="underline">Privacy Policy</a> and allow contact about my move.</label>
-          </div>
-          <div class="flex flex-wrap gap-2">
-            <button id="btnSend" class="px-4 py-2 rounded-lg bg-[var(--brand-700)] hover:bg-[var(--brand-800)] text-white">Send to MFTNB</button>
-            <button id="btnEditInfo" class="px-4 py-2 rounded-lg border">Edit answers</button>
-          </div>
-          <div class="mt-1">
-            <div class="cf-turnstile" data-sitekey="0x4AAAAAAB2gwLXxC5IfxB3W" data-theme="auto" data-size="compact"></div>
-          </div>
-          <details class="text-xs text-zinc-500">
-            <summary class="cursor-pointer">For office use</summary>
-            <div class="mt-2">
-              <div class="flex gap-2 mb-2">
-                <button id="btnCopy" class="px-3 py-1 rounded border text-xs">Copy JSON</button>
-                <button id="btnDownload" class="px-3 py-1 rounded border text-xs">Download JSON</button>
-                <button id="btnClear" class="px-3 py-1 rounded border text-xs">Clear</button>
+    <section id="services">
+      <div class="container">
+        <div class="section-heading">
+          <h2>Full-service moving tailored to your story</h2>
+          <p>From careful packing to specialty deliveries, we help homes, businesses, and community organizations transition smoothly.</p>
+        </div>
+        <div class="grid-cards">
+          <article class="card">
+            <h3>Local &amp; long-distance moves</h3>
+            <p>Professional loading, transport, and setup anywhere in Alberta—with route planning and friendly updates throughout your day.</p>
+          </article>
+          <article class="card">
+            <h3>Downsizing &amp; senior moves</h3>
+            <p>Extra-patient crews to help with sorting, packing, and placing treasured belongings exactly where you want them.</p>
+          </article>
+          <article class="card">
+            <h3>Furniture rescue &amp; donations</h3>
+            <p>We rehome quality furniture to families starting over and coordinate pickups from generous community donors.</p>
+          </article>
+          <article class="card">
+            <h3>Specialty items</h3>
+            <p>Pianos, safes, heirloom antiques, and more—planned with custom equipment and protective materials.</p>
+          </article>
+          <article class="card">
+            <h3>Packing &amp; unpacking</h3>
+            <p>Room-by-room packing, labeling, and unpacking help so your essentials are within reach the moment you arrive.</p>
+          </article>
+          <article class="card">
+            <h3>Cleaning &amp; junk removal</h3>
+            <p>Add-on crews to leave spaces broom-clean or remove unwanted items responsibly after your move.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="community">
+      <div class="container highlight">
+        <h3>Community commitment led by Chris Ehret</h3>
+        <p>Founder Chris Ehret built Moving Forward to New Beginnings after seeing how urgently families in Red Deer needed safe, discreet help leaving dangerous situations. Local coverage from <a href="https://rdnewsnow.com/2018/08/29/moving-company-helping-domestic-violence-victims-move-forward/" target="_blank" rel="noopener">rdnewsNOW</a> and <a href="https://www.alignable.com/red-deer-ab/moving-forward-to-new-beginnings" target="_blank" rel="noopener">Alignable</a> highlights how every series of paid moves funds a free “rescue move” for a survivor. Our crew also delivers donated furniture to people starting over—families escaping domestic violence, newcomers, and neighbours rebuilding after hardship. When you book a move, you keep that lifeline running.</p>
+      </div>
+    </section>
+
+    <section id="estimator" class="estimator-section">
+      <div class="container">
+        <div class="section-heading">
+          <h2>Guided chat-style estimate</h2>
+          <p>Answer a few friendly prompts, review your summary, and submit securely. You can pause anytime—your progress stays on this device until you send.</p>
+        </div>
+        <div class="estimator-layout">
+          <div class="chat-shell">
+            <div id="chatLog" class="chat-log" aria-live="polite"></div>
+            <form id="chatForm" class="chat-composer" autocomplete="off" novalidate>
+              <div class="composer-header">
+                <div id="promptText"></div>
+                <p id="promptHelper"></p>
               </div>
-              <pre id="jsonSummary" class="text-[10px] bg-zinc-50 p-2 rounded-lg overflow-auto max-h-40"></pre>
+              <div id="inputHolder"></div>
+              <p id="inputError" role="alert"></p>
+              <div class="composer-actions">
+                <button type="submit" id="chatSubmit" class="btn-primary">Start</button>
+              </div>
+              <p class="chat-complete-note" id="chatCompleteNote" hidden>You're ready to submit on the right-hand side.</p>
+            </form>
+          </div>
+          <aside class="summary-panel" aria-live="polite">
+            <h3>Your move summary</h3>
+            <div class="progress-wrap">
+              <div class="progress-bar" aria-hidden="true"><span id="progressBar" style="width:0%"></span></div>
+              <div id="progressText">Step 1 of 12</div>
             </div>
-          </details>
-          <p id="sendStatus" class="text-sm"></p>
-          <div class="text-xs text-zinc-500">By submitting, you consent to us contacting you about your move. We never sell your info.</div>
-        </aside>
+            <div class="notice">We only submit your answers after you press <strong>Send to MFTNB</strong>.</div>
+            <div id="summaryList" class="summary-list" role="list"></div>
+            <div class="checkbox-consent">
+              <input type="checkbox" id="consent" />
+              <label for="consent">I agree to the <a href="privacy.html" target="_blank" rel="noopener">Privacy Policy</a> and allow the team to contact me about my move.</label>
+            </div>
+            <div id="estimateTurnstile" class="turnstile-slot" aria-live="polite"></div>
+            <div class="action-buttons">
+              <button type="button" id="sendEstimate" class="btn-submit" disabled>Send to MFTNB</button>
+              <button type="button" id="restartEstimate" class="btn-link">Start over</button>
+            </div>
+            <p id="estimateStatus" class="status-message" role="status"></p>
+          </aside>
+        </div>
       </div>
-    </div>
-  </section>
+    </section>
 
-  <section id="contact" class="py-16 bg-zinc-100">
-    <div class="max-w-6xl mx-auto px-4 grid md:grid-cols-2 gap-8 items-start">
+    <section id="how-it-works">
+      <div class="container">
+        <div class="section-heading">
+          <h2>How the process works</h2>
+          <p>Every detail flows straight to our office and into your confirmation email after Turnstile verifies you are human.</p>
+        </div>
+        <div class="steps-grid">
+          <div class="step-card">
+            <div class="step-number">1</div>
+            <h3>Share your move details</h3>
+            <p>Answer bite-sized prompts—addresses, home layout, special items, and any extra support you need.</p>
+          </div>
+          <div class="step-card">
+            <div class="step-number">2</div>
+            <h3>Review &amp; verify</h3>
+            <p>Check the summary panel, agree to the privacy policy, and complete the Cloudflare Turnstile check to prevent spam.</p>
+          </div>
+          <div class="step-card">
+            <div class="step-number">3</div>
+            <h3>Receive confirmation</h3>
+            <p>You get an instant on-screen message and a detailed email recap. Our coordinator follows up quickly with next steps.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="testimonials">
+      <div class="container">
+        <div class="section-heading">
+          <h2>What neighbours are saying</h2>
+          <p>Families, shelters, and community partners trust our crews to move with heart. Explore highlights below and open our Google Reviews to read every 4 and 5-star experience.</p>
+        </div>
+        <div class="testimonial-wrap">
+          <article class="testimonial">
+            <p>“Chris and his team helped us move out of a dangerous situation quickly and safely. They treated us with absolute respect.”</p>
+            <span>Community survivor, featured by rdnewsNOW</span>
+          </article>
+          <article class="testimonial">
+            <p>“For every set of paid moves they complete, they perform a rescue move at no charge. That’s why we refer families their way.”</p>
+            <span>Partner highlight via Alignable</span>
+          </article>
+          <article class="testimonial">
+            <p>“They went above and beyond—careful with every item and full of encouragement when we felt overwhelmed.”</p>
+            <span>Google reviewer</span>
+          </article>
+        </div>
+        <div class="reviews-embed" aria-label="Google Maps reviews">
+          <iframe title="Moving Forward to New Beginnings Google Reviews" src="https://maps.google.com/maps?hl=en&amp;q=Moving%20Forward%20to%20New%20Beginnings%20Red%20Deer%20AB&amp;output=embed" width="100%" height="420" style="border:0;" loading="lazy" allowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>
+        </div>
+        <div class="hero-actions" style="margin-top:2rem;">
+          <a class="btn-secondary" href="https://www.google.com/maps/place/Moving+Forward+To+New+Beginnings/@52.268,-113.811,14z/data=!3m1!4b1!4m8!3m7!1s0x0:0x0!8m2!3d52.268!4d-113.811!9m1!1b1!16s%2Fg%2F11c5s1d3p1?entry=ttu" target="_blank" rel="noopener">Open Google Reviews</a>
+        </div>
+      </div>
+    </section>
+
+    <section id="faq">
+      <div class="container">
+        <div class="section-heading">
+          <h2>Frequently asked questions</h2>
+          <p>Reach out anytime if you need anything beyond these answers—we are happy to help.</p>
+        </div>
+        <div class="faq-grid">
+          <article class="faq-card">
+            <h3>How quickly will you contact me after I submit?</h3>
+            <p>Our move coordinator reviews new estimates throughout the day. Expect a confirmation email right away and a personal follow-up call within one business day (often sooner).</p>
+          </article>
+          <article class="faq-card">
+            <h3>Do you provide packing supplies?</h3>
+            <p>Yes. Let us know in the chat if you need boxes, wardrobe cartons, mattress bags, or eco-friendly totes. We can deliver supplies ahead of time or bring everything on move day.</p>
+          </article>
+          <article class="faq-card">
+            <h3>Can you help furnish a new home?</h3>
+            <p>Absolutely. We maintain an inventory of donated furniture and household goods. If you or someone you know is rebuilding, mention it in the notes and we’ll coordinate deliveries.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="contact">
+      <div class="container contact-grid">
+        <div class="contact-card">
+          <h3>Connect with our team</h3>
+          <ul class="contact-list">
+            <li>
+              <strong>Call or text</strong>
+              <span><a href="tel:+15877310695">(587) 731-0695</a></span>
+            </li>
+            <li>
+              <strong>Email</strong>
+              <span><a href="mailto:info@mftnb.ca">info@mftnb.ca</a></span>
+            </li>
+            <li>
+              <strong>Facebook</strong>
+              <span><a href="https://www.facebook.com/movingforwardtonewbeginnings/" target="_blank" rel="noopener">Moving Forward to New Beginnings</a></span>
+            </li>
+          </ul>
+          <p>Prefer to leave a short message? Use the form and we’ll respond promptly. Turnstile protects this inbox from spam so your note reaches us.</p>
+        </div>
+        <div class="contact-card">
+          <h3>Quick message</h3>
+          <form id="quickForm" class="quick-form" novalidate>
+            <div>
+              <label for="quickName">Your name *</label>
+              <input id="quickName" name="name" autocomplete="name" required />
+            </div>
+            <div>
+              <label for="quickEmail">Email</label>
+              <input id="quickEmail" name="email" type="email" autocomplete="email" />
+            </div>
+            <div>
+              <label for="quickPhone">Phone</label>
+              <input id="quickPhone" name="phone" type="tel" inputmode="tel" autocomplete="tel" />
+            </div>
+            <div>
+              <label for="quickMessage">How can we help? *</label>
+              <textarea id="quickMessage" name="message" required></textarea>
+            </div>
+            <div id="quickTurnstile" class="turnstile-slot" aria-live="polite"></div>
+            <button type="submit" class="btn-primary">Send message</button>
+            <p id="quickStatus" role="status"></p>
+          </form>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-grid">
       <div>
-        <h2 class="text-2xl font-bold">Contact</h2>
-        <p class="mt-3 text-zinc-600">Call, email, or send the estimate—whatever’s easiest.</p>
-        <ul class="mt-4 space-y-2 text-sm">
-          <li><span class="font-medium">Phone:</span> <a href="tel:+15877310695" class="underline">(587) 731-0695</a></li>
-          <li><span class="font-medium">Email:</span> <a href="mailto:info@mftnb.ca" class="underline">info@mftnb.ca</a></li>
-          <li><span class="font-medium">Hours:</span> Mon–Fri 9–6, Sat 10–2</li>
-          <li><span class="font-medium">Area:</span> Red Deer & surrounding communities</li>
+        <h4>Moving Forward to New Beginnings</h4>
+        <p>Serving Red Deer and Central Alberta families with respectful, community-driven moving support.</p>
+      </div>
+      <div>
+        <h4>Explore</h4>
+        <ul class="footer-nav">
+          <li><a href="#services">Services</a></li>
+          <li><a href="#community">Community mission</a></li>
+          <li><a href="#estimator">Estimate chat</a></li>
+          <li><a href="#testimonials">Testimonials</a></li>
         </ul>
       </div>
-      <div class="p-5 rounded-2xl bg-white border border-zinc-200 shadow-sm">
-        <h3 class="font-semibold">Quick Message</h3>
-        <form class="mt-3 grid gap-3" onsubmit="event.preventDefault(); window.scrollTo({top: document.getElementById('estimator').offsetTop, behavior:'smooth'});">
-          <input class="px-3 py-2 rounded-lg border" placeholder="Your name" />
-          <input class="px-3 py-2 rounded-lg border" placeholder="Email" />
-          <textarea class="px-3 py-2 rounded-lg border" rows="3" placeholder="Message" ></textarea>
-          <button class="px-4 py-2 rounded-lg bg-zinc-900 text-white">Start Estimate</button>
-        </form>
+      <div>
+        <h4>Contact</h4>
+        <ul class="footer-contact">
+          <li><a href="tel:+15877310695">(587) 731-0695</a></li>
+          <li><a href="mailto:info@mftnb.ca">info@mftnb.ca</a></li>
+          <li><a href="https://www.facebook.com/movingforwardtonewbeginnings/" target="_blank" rel="noopener">Facebook</a></li>
+        </ul>
       </div>
     </div>
-  </section>
-
-  <div id="welcome" class="fixed inset-0 bg-black/40 backdrop-blur-sm grid place-items-center p-4 hidden">
-    <div class="bg-white rounded-2xl shadow-xl max-w-lg w-full p-6 fade-in">
-      <div class="flex items-center gap-3">
-        <img src="logo.png" alt="Moving Forward to New Beginnings logo" class="h-10 w-auto select-none" onerror="this.onerror=null;this.src='data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27200%27%20height%3D%2748%27%3E%3Ctext%20x%3D%270%27%20y%3D%2736%27%20font-family%3D%27Inter%2C%20system-ui%2C%20Arial%27%20font-size%3D%2736%27%20font-weight%3D%27700%27%20fill%3D%27%23992e34%27%3EMFTNB%3C/text%3E%3C/svg%3E';">
-        <h3 class="text-xl font-semibold">Get a fast, friendly estimate</h3>
-      </div>
-      <p class="mt-3 text-zinc-600">Takes about 2 minutes. No payment or login required. You can save and come back anytime.</p>
-      <ul class="mt-3 text-sm text-zinc-600 list-disc ml-5">
-        <li>We’ll ask for contact + addresses</li>
-        <li>Room-by-room inventory (with easy counters)</li>
-        <li>Pick your date/time window</li>
-      </ul>
-      <div class="mt-5 flex items-center justify-end gap-2">
-        <button id="btnSkip" class="px-4 py-2 rounded-lg border">Maybe later</button>
-        <button id="btnStart" class="px-4 py-2 rounded-lg bg-[var(--brand-700)] text-white hover:bg-[var(--brand-800)]">Start</button>
-      </div>
-    </div>
-  </div>
-
-  <div id="policyModal" class="fixed inset-0 bg-black/40 backdrop-blur-sm grid place-items-center p-4 hidden">
-    <div class="bg-white rounded-2xl shadow-xl max-w-2xl w-full p-6 fade-in">
-      <div class="flex items-start justify-between gap-3">
-        <h3 class="text-xl font-semibold">Privacy Policy</h3>
-        <button id="closePolicy" class="px-3 py-1 rounded-lg border">Close</button>
-      </div>
-      <div class="mt-3 text-sm text-zinc-700 space-y-3 max-h-[70vh] overflow-auto">
-        <p><strong>What we collect:</strong> name, contact details, pickup/drop-off addresses, desired move date/time, and your inventory list. This helps us provide an accurate estimate and schedule your move.</p>
-        <p><strong>How we use it:</strong> to contact you with an estimate, coordinate your move, and improve our services. We do not sell your data.</p>
-        <p><strong>Where it’s stored:</strong> securely in our internal systems (Google Workspace/Sheets) with access restricted to staff who need it.</p>
-        <p><strong>How long we keep it:</strong> we retain leads for up to 12 months unless you ask us to delete them sooner.</p>
-        <p><strong>Your choices:</strong> you can request access or deletion of your information by emailing <a href="mailto:info@mftnb.ca" class="underline">info@mftnb.ca</a>.</p>
-        <p>This site is operated in Alberta and we follow the Alberta Personal Information Protection Act (PIPA).</p>
-      </div>
-    </div>
-  </div>
-
-  <div class="fixed bottom-0 inset-x-0 md:hidden bg-white/95 border-t backdrop-blur px-4 py-3 flex items-center justify-between gap-3 z-50">
-    <span class="text-sm font-medium">Get your free estimate</span>
-    <a href="#estimator" class="px-4 py-2 rounded-lg bg-[var(--brand-700)] text-white hover:bg-[var(--brand-800)]">Start</a>
-  </div>
-
-  <footer class="py-10 border-t bg-white">
-    <div class="max-w-6xl mx-auto px-4 text-sm text-zinc-500 flex flex-wrap items-center justify-between gap-3">
-      <div>© <span id="year"></span> Moving Forward to New Beginnings</div>
-      <div><a href="#" id="openPolicyFooter" class="underline">Privacy Policy</a> · All rights reserved.</div>
+    <div class="container footer-bottom">
+      <span>&copy; <span id="currentYear"></span> Moving Forward to New Beginnings.</span>
+      <a href="privacy.html">Privacy Policy</a>
     </div>
   </footer>
 
-  <script>
-  const BACKEND = {
-    mode: 'apps_script',
-appsScriptUrl: 'https://script.google.com/macros/s/AKfycbz2kTp_RynPKZptrLJrsv_DvS_-el2bzBz8Jc_QaEej2nHop5iABnMcuEa5pff2No9W8g/exec'
-  };
-</script>
-
-  const KEY = 'mftnb_estimate_v1'; let state = JSON.parse(localStorage.getItem(KEY) || '{}');
-  const steps = [
-    { id:'intro',   prompt: "Welcome! Let's get a quick estimate started. What's your full name?", field:'name', type:'text', required:true, group:1 },
-    { id:'contact', prompt: "Great, what's the best email to reach you?", field:'email', type:'email', required:true, group:1 },
-    { id:'phone',   prompt: "And your phone number?", field:'phone', type:'tel', required:true, group:1 },
-    { id:'pickup',  prompt: 'Pickup address (include unit/floor and city):', field:'pickup', type:'textarea', required:true, group:2 },
-    { id:'dropoff', prompt: 'Drop-off address (include unit/floor and city):', field:'dropoff', type:'textarea', required:true, group:2 },
-    { id:'date',    prompt: 'Desired move date:', field:'moveDate', type:'date', required:true, group:3 },
-    { id:'window',  prompt: 'Preferred time window?', field:'timeWindow', type:'select', options:['Morning','Midday','Afternoon','Flexible'], group:3 },
-    { id:'home',    prompt: 'Home size?', field:'homeSize', type:'select', options:['Studio','1 Bedroom','2 Bedroom','3 Bedroom','4+ Bedroom'], group:4 },
-    { id:'access',  prompt: 'Any stairs, elevator, or tight access at either location?', field:'access', type:'textarea', group:4 },
-    { id:'rooms',   prompt: 'List main items per room. You can add custom items later.', field:'inventory', type:'inventory', group:5 },
-    { id:'extras',  prompt: 'Any extras?', field:'extras', type:'multi', options:['Packing Service','Junk Removal','Clean-out','Piano / Specialty Item'], group:6 },
-    { id:'notes',   prompt: 'Anything else we should know?', field:'notes', type:'textarea', group:6 },
-    { id:'review',  prompt: 'Review your details, then check the Privacy box and press Send.', field:'review', type:'review', group:7 },
-  ];
-  let stepIndex = Math.min(Number(state._stepIndex || 0), steps.length - 1);
-  const chatEl = document.getElementById('chat'); const inputEl = document.getElementById('chatInput'); const nextBtn = document.getElementById('chatNext');
-  const summaryCards = document.getElementById('summaryCards'); const jsonSummary = document.getElementById('jsonSummary'); const currentPromptEl = document.getElementById('currentPrompt');
-  const nextLabelEl = document.getElementById('nextLabel'); const composer = document.getElementById('composer'); const editBtn = document.getElementById('btnEditInfo');
-  const progressBar = document.getElementById('progressBar'); const stepper = document.getElementById('stepper'); const stepLabel = document.getElementById('stepLabel');
-  const sendBtn = document.getElementById('btnSend'); const copyBtn = document.getElementById('btnCopy'); const dlBtn = document.getElementById('btnDownload'); const clearBtn = document.getElementById('btnClear');
-  const statusEl = document.getElementById('sendStatus'); const consent = document.getElementById('consent'); const openPolicy = document.getElementById('openPolicy'); const openPolicyFooter = document.getElementById('openPolicyFooter');
-  const policyModal = document.getElementById('policyModal'); const closePolicy = document.getElementById('closePolicy'); const welcome = document.getElementById('welcome');
-  const btnStart = document.getElementById('btnStart'); const btnSkip = document.getElementById('btnSkip');
-  document.getElementById('year').textContent = new Date().getFullYear();
-  function msg(role, html) { const wrap = document.createElement('div'); wrap.className = role === 'agent' ? 'flex gap-3' : 'flex gap-3 justify-end'; const bubble = document.createElement('div'); bubble.className = 'max-w-[85%] px-3 py-2 rounded-2xl text-sm shadow border ' + (role==='agent' ? 'bg-white border-zinc-200' : 'bg-zinc-900 text-white border-transparent'); bubble.innerHTML = html; wrap.appendChild(bubble); chatEl.appendChild(wrap); chatEl.scrollTop = chatEl.scrollHeight; }
-  function setProgress(){ const p=Math.round((stepIndex)/(steps.length-1)*100); progressBar.style.width=p+'%'; stepLabel.textContent=`Step ${Math.min(stepIndex+1,steps.length)} of ${steps.length}`; const g=steps[stepIndex].group; stepper.querySelectorAll('li').forEach((el,i)=>{const idx=i+1; el.className='px-2 py-1 rounded '+(idx===g?'bg-[var(--brand-100)] text-[var(--brand-900)] font-medium':idx<g?'bg-zinc-200 text-zinc-700':'bg-zinc-100');}); }
-  function save(){ localStorage.setItem(KEY, JSON.stringify({...state,_stepIndex:stepIndex})); renderSummary(); }
-  function computeEstimate(s){ const inv=s.inventory||{}; const weights={'Boxes':1,'Sofa':15,'Bed (Queen)':12,'Mattress':8,'Dresser':8,'Dining Table':12,'Chairs':3,'TV':3,'Desk':6,'Wardrobe':8,'Washer':10,'Dryer':10,'Fridge':12}; let units=0; for(const k in inv){ const v=Number(inv[k])||0; units+=(weights[k]||5)*v; } const crew=units<30?2:units<60?3:4; const hours=Math.max(2,Math.round((2+units/15)*2)/2); return {units,recommendedCrew:crew,estimatedHours:hours,note:'Rough estimate — subject to walkthrough'}; }
-  function renderSummary(){ const out={...state}; delete out._stepIndex; const inv=out.inventory||{}; const itemCount=Object.values(inv).reduce((a,b)=>a+(Number(b)||0),0); const extrasChips=(out.extras||[]).map(x=>`<span class="inline-block rounded-full bg-zinc-100 border px-2 py-0.5 mr-1">${x}</span>`).join('')||'<span class="text-zinc-400">None</span>'; const est=computeEstimate(out);
-    const contactCard=`<div class="p-3 rounded-xl border"><div class="font-medium mb-1">Contact</div><div>${out.name||'<span class="text-zinc-400">Your name</span>'}</div><div>${out.phone||'<span class="text-zinc-400">Phone</span>'}</div><div class="truncate">${out.email||'<span class="text-zinc-400">Email</span>'}</div></div>`;
-    const moveCard=`<div class="p-3 rounded-xl border"><div class="font-medium mb-1">Move details</div><div><span class="text-zinc-500">Date:</span> ${out.moveDate||'—'} ${out.timeWindow?'('+out.timeWindow+')':''}</div><div class="mt-1"><span class="text-zinc-500">Pickup:</span> ${out.pickup||'—'}</div><div class="mt-1"><span class="text-zinc-500">Drop-off:</span> ${out.dropoff||'—'}</div></div>`;
-    const invCard=`<div class="p-3 rounded-xl border"><div class="font-medium mb-1">Inventory</div><div>${itemCount} items listed</div><div class="mt-1">${extrasChips}</div></div>`;
-    const estCard=`<div class="p-3 rounded-xl border bg-[var(--brand-50)]"><div class="font-medium mb-1">Rough estimate</div><div>Recommended crew: <span class="font-medium">${est.recommendedCrew}</span></div><div>Estimated hours: <span class="font-medium">${est.estimatedHours}</span></div><div class="text-xs text-zinc-600 mt-1">${est.note}</div></div>`;
-    summaryCards.innerHTML=contactCard+moveCard+invCard+estCard; jsonSummary.textContent=JSON.stringify(out,null,2);
-  }
-  function askCurrent(){ const s=steps[stepIndex]; setProgress(); if(!s)return; currentPromptEl.textContent=s.prompt;
-    if(s.type==='inventory'){ msg('agent', `<div class="font-medium">${s.prompt}</div><div class="mt-1 text-zinc-600">Start with preset items, then add more.</div>`); renderInventoryUI(); inputEl.value=state[s.field]||''; inputEl.placeholder='Add a custom item (e.g., "Bookshelf x1") and press Enter'; updateNextState(); return; }
-    if(s.type==='multi'){ msg('agent', `<div class="font-medium">${s.prompt}</div>`); const opts=s.options.map(o=>`<label class='inline-flex items-center gap-2 mr-2 mt-2'><input type='checkbox' value='${o}' class='extrasOpt'> <span>${o}</span></label>`).join(''); msg('agent', `<div class='p-2'>${opts}</div>`); inputEl.value=''; inputEl.placeholder='Select options, add notes if needed'; updateNextState(); return; }
-    if(s.type==='review'){ msg('agent', `<div class='font-medium'>${s.prompt}</div>`); inputEl.value=''; inputEl.placeholder='Review on the right, then press Send'; updateNextState(); return; }
-    msg('agent', `<div class="font-medium">${s.prompt}</div>`); inputEl.type=(s.type==='textarea'?'text':s.type); inputEl.value=state[s.field]||''; inputEl.placeholder=''; updateNextState();
-  }
-  function saveAnswerFromInput(){ const s=steps[stepIndex]; if(!s)return true;
-    if(s.type==='inventory')return true; if(s.type==='multi'){ const values=Array.from(document.querySelectorAll('.extrasOpt:checked')).map(el=>el.value); state[s.field]=values; save(); return true; } if(s.type==='review')return true;
-    const val=inputEl.value.trim(); if(s.required && !val) return false; if(s.type==='email'){ const ok=/.+@.+\..+/.test(val); if(!ok){ alert('Please enter a valid email.'); return false; } } if(s.field==='phone' && val){ const digits=val.replace(/\D/g,''); if(digits.length<10){ alert('Please enter a valid phone number.'); return false; } }
-    state[s.field]=val; msg('user', val?val.replace(/</g,'&lt;'):'<span class="text-zinc-400">(skipped)</span>'); save(); return true;
-  }
-  function next(){ if(!saveAnswerFromInput())return; stepIndex=Math.min(stepIndex+1,steps.length-1); save(); askCurrent(); }
-  inputEl.addEventListener('keydown', e=>{ if(e.key==='Enter'){ e.preventDefault(); next(); } }); inputEl.addEventListener('input', updateNextState); inputEl.addEventListener('focus', ()=>{ setTimeout(()=>{ composer.scrollIntoView({block:'end',behavior:'smooth'}); }, 80); }); nextBtn.addEventListener('click', next); if(editBtn) editBtn.onclick=()=>{ document.getElementById('estimator').scrollIntoView({behavior:'smooth'}); setTimeout(()=>composer.scrollIntoView({block:'end'}),250); };
-  function renderInventoryUI(){ const wrap=document.createElement('div'); wrap.className='bg-white border border-zinc-200 rounded-xl p-3'; wrap.innerHTML=`<div class='grid grid-cols-2 sm:grid-cols-3 gap-2' id='invGrid'></div><div class='mt-3 flex gap-2'><input id='invCustom' class='flex-1 px-3 py-2 rounded-lg border' placeholder='Custom item (e.g., "Bookshelf")'><button id='addCustom' class='px-3 py-2 rounded-lg border'>Add</button></div>`; chatEl.appendChild(wrap);
-    const presets=[['Boxes',10],['Sofa',1],['Bed (Queen)',1],['Mattress',1],['Dresser',1],['Dining Table',1],['Chairs',4],['TV',1],['Desk',1],['Wardrobe',0],['Washer',0],['Dryer',0],['Fridge',0]]; if(!state.inventory) state.inventory={}; const grid=wrap.querySelector('#invGrid');
-    function card(name){ const count=state.inventory[name]||0; const div=document.createElement('div'); div.className='border rounded-lg p-2 text-sm flex items-center justify-between'; div.innerHTML=`<span>${name}</span><div class='flex items-center gap-2'><button class='px-2 py-1 rounded border' data-act='dec'>−</button><input class='w-14 text-center border rounded px-2 py-1' type='number' min='0' value='${count}'/><button class='px-2 py-1 rounded border' data-act='inc'>+</button></div>`;
-      div.querySelector('[data-act=inc]').onclick=()=>{ state.inventory[name]=(state.inventory[name]||0)+1; div.querySelector('input').value=state.inventory[name]; save(); };
-      div.querySelector('[data-act=dec]').onclick=()=>{ state.inventory[name]=Math.max(0,(state.inventory[name]||0)-1); div.querySelector('input').value=state.inventory[name]; save(); };
-      div.querySelector('input').onchange=e=>{ state.inventory[name]=Math.max(0, Number(e.target.value)||0); save(); };
-      grid.appendChild(div); }
-    presets.forEach(([n,_])=>card(n)); wrap.querySelector('#addCustom').onclick=()=>{ const n=wrap.querySelector('#invCustom').value.trim(); if(!n)return; if(!state.inventory[n]) state.inventory[n]=1; else state.inventory[n]+=1; wrap.querySelector('#invCustom').value=''; card(n); save(); };
-  }
-  function getTurnstileToken(){ return document.querySelector('input[name="cf-turnstile-response"]')?.value || ''; }
-  function buildPayload(){ const payload={...state,submittedAt:new Date().toISOString(),source:'mftnb-site',turnstileToken:getTurnstileToken()}; delete payload._stepIndex; return payload; }
-  async function sendSubmission(){ if(!consent.checked){ alert('Please agree to the Privacy Policy first.'); return; } const token=getTurnstileToken(); if(!token){ statusEl.textContent='Please complete the security check above and try again.'; return; } statusEl.textContent='Sending…'; const data=buildPayload();
-    try{ const res=await fetch(BACKEND.appsScriptUrl,{ method:'POST', headers:{'Content-Type':'text/plain;charset=utf-8'}, body: JSON.stringify(data) }); const text=await res.text(); let json; try{ json=JSON.parse(text); } catch { json={ ok: res.ok, status: res.status, body: text }; } if(!res.ok || (json && json.ok===false)){ const msg=(json && json.error)?json.error:`HTTP ${res.status} ${text||''}`.trim(); throw new Error(msg); } statusEl.textContent='Sent! We\\'ll be in touch shortly.'; return json; }
-    catch(e){ console.error(e); statusEl.textContent='Could not send. '+String(e && e.message ? e.message : e); return { ok:false, error:String(e) }; } }
-  sendBtn.onclick=sendSubmission; copyBtn.onclick=()=>{ navigator.clipboard.writeText(JSON.stringify(buildPayload(),null,2)); statusEl.textContent='Copied to clipboard'; };
-  dlBtn.onclick=()=>{ const blob=new Blob([JSON.stringify(buildPayload(),null,2)],{type:'application/json'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='mftnb-estimate.json'; a.click(); };
-  if(clearBtn) clearBtn.onclick=()=>{ if(confirm('Clear your saved estimate?')){ localStorage.removeItem(KEY); state={}; stepIndex=0; chatEl.innerHTML=''; jsonSummary.textContent=''; summaryCards.innerHTML=''; askCurrent(); setProgress(); } };
-  function togglePolicy(open){ policyModal.classList[open?'remove':'add']('hidden'); } if(openPolicy) openPolicy.onclick=e=>{ e.preventDefault(); togglePolicy(true); }; if(openPolicyFooter) openPolicyFooter.onclick=e=>{ e.preventDefault(); togglePolicy(true); }; if(closePolicy) closePolicy.onclick=()=> togglePolicy(false);
-  function updateNextState(){ const s=steps[stepIndex]; if(!s)return; const requiredEmpty=!!(s.required && !inputEl.value.trim() && s.type!=='multi' && s.type!=='inventory' && s.type!=='review'); nextLabelEl.textContent=(stepIndex===0 && requiredEmpty)?'Start':'Next'; nextBtn.disabled=requiredEmpty; }
-  function maybeShowWelcome(){ const isFresh=!localStorage.getItem(KEY) || Object.keys(state).length===0; if(isFresh){ welcome.classList.remove('hidden'); nextBtn.disabled=true; nextLabelEl.textContent='Start'; } else { if(!chatEl.children.length) askCurrent(); } } if(btnStart) btnStart.onclick=()=>{ welcome.classList.add('hidden'); if(!chatEl.children.length) askCurrent(); setTimeout(()=>composer.scrollIntoView({block:'end',behavior:'smooth'}),150); }; if(btnSkip) btnSkip.onclick=()=>{ welcome.classList.add('hidden'); document.getElementById('services').scrollIntoView({behavior:'smooth'}); };
-  renderSummary(); setProgress(); maybeShowWelcome(); if(!welcome || welcome.classList.contains('hidden')){ if(!chatEl.children.length) askCurrent(); }
-  </script>
+  <script src="script.js" defer></script>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy Policy | Moving Forward to New Beginnings</title>
+  <meta name="description" content="Learn how Moving Forward to New Beginnings collects, uses, and protects personal information for moving estimates and community programs in Red Deer." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="64x64" href="favicon-64.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+  <link rel="shortcut icon" href="favicon.ico" />
+</head>
+<body>
+  <header class="site-header">
+    <div class="inner">
+      <a href="index.html" class="brand" aria-label="Back to Moving Forward to New Beginnings home">
+        <img src="logo.png" alt="Moving Forward to New Beginnings logo" />
+        <span>Moving Forward to New Beginnings</span>
+      </a>
+      <nav class="primary-nav" aria-label="Privacy navigation">
+        <a href="index.html#estimator">Estimate</a>
+        <a href="index.html#community">Community</a>
+        <a href="index.html#contact">Contact</a>
+      </nav>
+      <div class="header-cta">
+        <a href="tel:+15877310695">(587) 731-0695</a>
+        <a href="mailto:info@mftnb.ca">info@mftnb.ca</a>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero" style="padding-top:4rem;padding-bottom:3rem;">
+      <div class="container">
+        <h1>Privacy Policy</h1>
+        <p>We respect the trust you place in Moving Forward to New Beginnings. This policy explains what information we collect, how it is used, and the safeguards that protect every client—including neighbours rebuilding after difficult circumstances.</p>
+      </div>
+    </section>
+
+    <section>
+      <div class="container">
+        <div class="section-heading" style="margin-bottom:2rem;">
+          <h2>Who we are</h2>
+          <p>Moving Forward to New Beginnings (MFTNB) is a Red Deer-based moving company led by founder Chris Ehret. For over a decade we have provided professional moving services, community rescue moves for domestic violence survivors, and furniture rehoming support across Central Alberta.</p>
+        </div>
+        <div class="grid-cards">
+          <article class="card">
+            <h3>Contact details</h3>
+            <p>Email: <a href="mailto:info@mftnb.ca">info@mftnb.ca</a><br />Phone: <a href="tel:+15877310695">(587) 731-0695</a><br />Mailing: Red Deer, Alberta</p>
+          </article>
+          <article class="card">
+            <h3>Services covered</h3>
+            <p>This policy applies to our moving estimate chat, quick contact form, confirmation emails, and community support programs managed by MFTNB.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="container">
+        <div class="section-heading" style="margin-bottom:2rem;">
+          <h2>Information we collect</h2>
+          <p>We only collect details needed to plan your move, deliver furniture, or coordinate community rescue support.</p>
+        </div>
+        <div class="grid-cards">
+          <article class="card">
+            <h3>Estimate chat &amp; quick message</h3>
+            <p>We ask for your name, contact information, pickup and destination addresses, preferred dates, access instructions, inventory notes, and optional extras. The chat also stores your answers temporarily in your browser so you can pause and resume before submitting.</p>
+          </article>
+          <article class="card">
+            <h3>Community requests</h3>
+            <p>When coordinating furniture deliveries or rescue moves, we may record the support agency involved, safe contact details, and household needs shared voluntarily by the client or a referring partner.</p>
+          </article>
+          <article class="card">
+            <h3>Safety &amp; security data</h3>
+            <p>Cloudflare Turnstile protects our forms from spam. It may collect technical information about your device to verify you are human. We do not receive your IP address or browsing history from Turnstile—only a verification token.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="container">
+        <div class="section-heading" style="margin-bottom:2rem;">
+          <h2>How we use your information</h2>
+        </div>
+        <div class="grid-cards">
+          <article class="card">
+            <h3>Preparing your move</h3>
+            <p>We use the details you provide to create estimates, schedule crews, plan equipment, and communicate updates before, during, and after your move.</p>
+          </article>
+          <article class="card">
+            <h3>Confirmations &amp; updates</h3>
+            <p>After Turnstile verification, your estimate or quick message is sent securely to our Google Workspace account. A confirmation email summarizing your answers is delivered automatically, and our coordinator follows up personally.</p>
+          </article>
+          <article class="card">
+            <h3>Community rescue moves</h3>
+            <p>When a shelter or community partner requests urgent help, we limit details to the minimum needed for safety—such as first names, safe phone numbers, and delivery instructions. Sensitive notes are stored separately with restricted access.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="container">
+        <div class="section-heading" style="margin-bottom:2rem;">
+          <h2>Sharing &amp; retention</h2>
+        </div>
+        <div class="grid-cards">
+          <article class="card">
+            <h3>We never sell data</h3>
+            <p>Your information is never sold or shared for advertising. We only provide details to trusted crew members or partner agencies directly involved in your move or donation.</p>
+          </article>
+          <article class="card">
+            <h3>Storage</h3>
+            <p>Estimate records are stored in a secure Google Sheet within our Google Workspace account. Access is limited to authorized team members. We review submissions annually and remove records that are no longer required for business or community obligations.</p>
+          </article>
+          <article class="card">
+            <h3>Your choices</h3>
+            <p>You can request a copy of your information, update it, or ask us to delete it by emailing <a href="mailto:info@mftnb.ca">info@mftnb.ca</a>. We respond within 5 business days.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="container highlight">
+        <h3>Community commitment</h3>
+        <p>Local coverage from <a href="https://rdnewsnow.com/2018/08/29/moving-company-helping-domestic-violence-victims-move-forward/" target="_blank" rel="noopener">rdnewsNOW</a> and <a href="https://www.alignable.com/red-deer-ab/moving-forward-to-new-beginnings" target="_blank" rel="noopener">Alignable</a> showcases how Chris Ehret and the MFTNB team reinvest moving revenue into free “rescue moves” for families fleeing domestic violence. Community posts on <a href="https://www.facebook.com/movingforwardtonewbeginnings/" target="_blank" rel="noopener">Facebook</a> highlight furniture donations that help neighbours starting over furnish safe homes. Protecting personal information is essential to every one of these missions.</p>
+      </div>
+    </section>
+
+    <section>
+      <div class="container">
+        <div class="section-heading" style="margin-bottom:2rem;">
+          <h2>Your privacy toolkit</h2>
+        </div>
+        <div class="grid-cards">
+          <article class="card">
+            <h3>Update or delete</h3>
+            <p>Email <a href="mailto:info@mftnb.ca">info@mftnb.ca</a> with “Privacy request” in the subject line. We will confirm completion of your request.</p>
+          </article>
+          <article class="card">
+            <h3>Security questions</h3>
+            <p>Ask for our privacy lead if you have concerns about how information is stored, shared, or removed. We will provide a clear response and timeline.</p>
+          </article>
+          <article class="card">
+            <h3>Policy updates</h3>
+            <p>We review this policy at least once per year. Major updates will be posted on this page with a revised “last updated” date.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="container" style="text-align:center;">
+        <p><strong>Last updated:</strong> September 21, 2025</p>
+        <a class="btn-secondary" href="index.html">Return to the homepage</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-bottom">
+      <span>&copy; <span id="privacyYear"></span> Moving Forward to New Beginnings.</span>
+      <a href="index.html#contact">Contact us</a>
+    </div>
+  </footer>
+
+  <script>
+    document.getElementById('privacyYear').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,854 @@
+const APPS_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbz2kTp_RynPKZptrLJrsv_DvS_-el2bzBz8Jc_QaEej2nHop5iABnMcuEa5pff2No9W8g/exec';
+const TURNSTILE_SITE_KEY = '0x4AAAAAAB2gwLXxC5IfxB3W';
+const STORAGE_KEY = 'mftnb-estimate-v3';
+
+const questions = [
+  {
+    id: 'name',
+    label: 'Name',
+    type: 'text',
+    required: true,
+    placeholder: 'Jane Smith',
+    autocomplete: 'name',
+    prompt: () => '👋 Hi there! What is your name?',
+    helper: 'We will use it to personalize your estimate.'
+  },
+  {
+    id: 'email',
+    label: 'Email',
+    type: 'email',
+    required: true,
+    placeholder: 'you@example.com',
+    autocomplete: 'email',
+    prompt: state => `Nice to meet you${state.name ? `, ${state.name}` : ''}! What email should we send confirmations to?`
+  },
+  {
+    id: 'phone',
+    label: 'Phone',
+    type: 'tel',
+    required: true,
+    placeholder: '(587) 555-1234',
+    autocomplete: 'tel',
+    inputmode: 'tel',
+    prompt: () => 'What phone number can we call or text if we have questions about your move?'
+  },
+  {
+    id: 'fromAddress',
+    label: 'Moving from',
+    type: 'textarea',
+    required: true,
+    placeholder: '123 Main Street, Red Deer, AB',
+    autocomplete: 'street-address',
+    prompt: () => 'Where are you moving from? Please include the full address and city.'
+  },
+  {
+    id: 'toAddress',
+    label: 'Moving to',
+    type: 'textarea',
+    required: true,
+    placeholder: '456 New Place, Lacombe, AB',
+    prompt: () => 'Great! What is the destination address?' 
+  },
+  {
+    id: 'homeType',
+    label: 'Home type',
+    type: 'select',
+    required: true,
+    prompt: () => 'What type of home are you moving from?',
+    options: [
+      { value: '', label: 'Select an option' },
+      { value: 'Apartment / condo', label: 'Apartment / condo' },
+      { value: 'Townhouse / duplex', label: 'Townhouse / duplex' },
+      { value: 'Single-family home', label: 'Single-family home' },
+      { value: 'Acreage / farm', label: 'Acreage / farm' },
+      { value: 'Office / commercial', label: 'Office / commercial' },
+      { value: 'Storage unit', label: 'Storage unit' }
+    ]
+  },
+  {
+    id: 'bedrooms',
+    label: 'Bedrooms or main rooms',
+    type: 'select',
+    required: true,
+    prompt: () => 'How many bedrooms or primary rooms should we plan for?',
+    options: [
+      { value: '', label: 'Select an option' },
+      { value: 'Studio / bachelor', label: 'Studio / bachelor' },
+      { value: '1 bedroom', label: '1 bedroom' },
+      { value: '2 bedrooms', label: '2 bedrooms' },
+      { value: '3 bedrooms', label: '3 bedrooms' },
+      { value: '4+ bedrooms', label: '4+ bedrooms' }
+    ]
+  },
+  {
+    id: 'accessDetails',
+    label: 'Access details',
+    type: 'textarea',
+    required: true,
+    placeholder: 'Loading dock, elevator booking, stairs, parking instructions…',
+    prompt: () => 'Tell us about stairs, elevators, parking, or anything special at either location.'
+  },
+  {
+    id: 'moveDate',
+    label: 'Preferred move date',
+    type: 'date',
+    required: true,
+    prompt: () => 'What date would you like to move?'
+  },
+  {
+    id: 'moveTime',
+    label: 'Preferred time',
+    type: 'select',
+    required: false,
+    prompt: () => 'Do you have a preferred time of day?',
+    options: [
+      { value: '', label: 'Select an option (or leave blank)' },
+      { value: 'Morning (8–10 a.m.)', label: 'Morning (8–10 a.m.)' },
+      { value: 'Late morning (10 a.m.–12 p.m.)', label: 'Late morning (10 a.m.–12 p.m.)' },
+      { value: 'Afternoon (12–3 p.m.)', label: 'Afternoon (12–3 p.m.)' },
+      { value: 'Late afternoon (after 3 p.m.)', label: 'Late afternoon (after 3 p.m.)' },
+      { value: 'Flexible / unsure', label: 'Flexible / unsure' }
+    ],
+    helper: 'Skip if you are flexible—we will confirm a window with you.'
+  },
+  {
+    id: 'specialItems',
+    label: 'Special items',
+    type: 'textarea',
+    required: false,
+    placeholder: 'Piano, gun safe, large plants, fragile heirlooms…',
+    prompt: () => 'List any large or specialty items we should prepare extra equipment for.'
+  },
+  {
+    id: 'extraServices',
+    label: 'Extra services',
+    type: 'multiselect',
+    required: false,
+    prompt: () => 'Would you like help with any of these extras?',
+    helper: 'Choose all that apply or leave blank if not needed.',
+    options: [
+      { value: 'Packing & unpacking support', label: 'Packing & unpacking support' },
+      { value: 'Packing supplies delivered', label: 'Packing supplies delivered' },
+      { value: 'Furniture assembly / disassembly', label: 'Furniture assembly / disassembly' },
+      { value: 'Cleaning or junk removal', label: 'Cleaning or junk removal' },
+      { value: 'Storage solutions', label: 'Storage solutions' }
+    ]
+  },
+  {
+    id: 'notes',
+    label: 'Additional notes',
+    type: 'textarea',
+    required: false,
+    placeholder: 'Timeline preferences, gate codes, who to contact onsite…',
+    prompt: () => 'Anything else we should know to make move day smooth?'
+  }
+];
+
+const summaryDefinitions = [
+  { id: 'name', label: 'Name' },
+  { id: 'email', label: 'Email' },
+  { id: 'phone', label: 'Phone' },
+  { id: 'fromAddress', label: 'Moving from' },
+  { id: 'toAddress', label: 'Moving to' },
+  {
+    id: 'schedule',
+    label: 'Move date & time',
+    formatter: state => {
+      if (!state.moveDate) return 'Choose a date that fits your plans.';
+      const formatted = formatDate(state.moveDate);
+      const time = state.moveTime ? ` · ${state.moveTime}` : '';
+      return `${formatted}${time}`;
+    }
+  },
+  {
+    id: 'homeDetails',
+    label: 'Home details',
+    formatter: state => {
+      const pieces = [state.homeType, state.bedrooms].filter(Boolean);
+      return pieces.length ? pieces.join(' · ') : 'Describe the type of home and number of rooms.';
+    }
+  },
+  {
+    id: 'accessDetails',
+    label: 'Access & parking',
+    formatter: state => state.accessDetails || 'Let us know about stairs, elevators, or parking instructions.'
+  },
+  {
+    id: 'specialItems',
+    label: 'Large or specialty items',
+    formatter: state => {
+      if (state.specialItems) return state.specialItems;
+      if (Object.prototype.hasOwnProperty.call(state, 'specialItems')) {
+        return 'None noted.';
+      }
+      return 'List heavy or fragile items so we can plan ahead.';
+    }
+  },
+  {
+    id: 'extraServices',
+    label: 'Extra services',
+    formatter: state => {
+      if (Array.isArray(state.extraServices) && state.extraServices.length) {
+        return state.extraServices.join('\n');
+      }
+      if (Object.prototype.hasOwnProperty.call(state, 'extraServices')) {
+        return 'No extra services selected.';
+      }
+      return 'Choose all that apply or leave blank if not needed.';
+    }
+  },
+  {
+    id: 'notes',
+    label: 'Additional notes',
+    formatter: state => {
+      if (state.notes) return state.notes;
+      if (Object.prototype.hasOwnProperty.call(state, 'notes')) {
+        return 'No additional notes.';
+      }
+      return 'Add timing requests, storage needs, or anything else.';
+    }
+  }
+];
+
+let estimateState = loadState();
+let estimateTurnstileToken = null;
+let estimateWidgetId = null;
+let quickTurnstileToken = null;
+let quickWidgetId = null;
+let isSubmittingEstimate = false;
+
+const chatLog = document.getElementById('chatLog');
+const chatForm = document.getElementById('chatForm');
+const promptText = document.getElementById('promptText');
+const promptHelper = document.getElementById('promptHelper');
+const inputHolder = document.getElementById('inputHolder');
+const inputError = document.getElementById('inputError');
+const chatSubmit = document.getElementById('chatSubmit');
+const chatCompleteNote = document.getElementById('chatCompleteNote');
+const progressBar = document.getElementById('progressBar');
+const progressText = document.getElementById('progressText');
+const summaryList = document.getElementById('summaryList');
+const consentCheckbox = document.getElementById('consent');
+const sendEstimateBtn = document.getElementById('sendEstimate');
+const restartBtn = document.getElementById('restartEstimate');
+const estimateStatus = document.getElementById('estimateStatus');
+const quickForm = document.getElementById('quickForm');
+const quickStatus = document.getElementById('quickStatus');
+const quickNameInput = document.getElementById('quickName');
+const quickEmailInput = document.getElementById('quickEmail');
+const quickPhoneInput = document.getElementById('quickPhone');
+const quickMessageInput = document.getElementById('quickMessage');
+const currentYearEl = document.getElementById('currentYear');
+
+let activeQuestionIndex = findNextQuestionIndex();
+let activeInputElement = null;
+
+if (currentYearEl) {
+  currentYearEl.textContent = new Date().getFullYear();
+}
+
+if (chatForm) {
+  renderEstimator();
+  chatForm.addEventListener('submit', handleChatSubmit);
+}
+
+if (restartBtn) {
+  restartBtn.addEventListener('click', () => {
+    estimateState = {};
+    saveState();
+    clearStatus(estimateStatus);
+    consentCheckbox.checked = false;
+    if (estimateWidgetId && window.turnstile) {
+      window.turnstile.reset(estimateWidgetId);
+    }
+    estimateTurnstileToken = null;
+    renderEstimator();
+  });
+}
+
+if (consentCheckbox) {
+  consentCheckbox.addEventListener('change', updateSubmitAvailability);
+}
+
+if (sendEstimateBtn) {
+  sendEstimateBtn.addEventListener('click', submitEstimate);
+}
+
+if (quickForm) {
+  quickForm.addEventListener('submit', submitQuickMessage);
+}
+
+function initializeTurnstileWidgets() {
+  if (!window.turnstile) return;
+  window.turnstile.ready(() => {
+    if (document.getElementById('estimateTurnstile') && !estimateWidgetId) {
+      estimateWidgetId = window.turnstile.render('#estimateTurnstile', {
+        sitekey: TURNSTILE_SITE_KEY,
+        action: 'estimate',
+        theme: 'light',
+        callback: token => {
+          estimateTurnstileToken = token;
+          updateSubmitAvailability();
+        },
+        'error-callback': () => {
+          estimateTurnstileToken = null;
+          updateSubmitAvailability();
+        },
+        'expired-callback': () => {
+          estimateTurnstileToken = null;
+          updateSubmitAvailability();
+        }
+      });
+    }
+
+    if (document.getElementById('quickTurnstile') && !quickWidgetId) {
+      quickWidgetId = window.turnstile.render('#quickTurnstile', {
+        sitekey: TURNSTILE_SITE_KEY,
+        action: 'quick_message',
+        theme: 'light',
+        size: 'compact',
+        callback: token => {
+          quickTurnstileToken = token;
+        },
+        'error-callback': () => {
+          quickTurnstileToken = null;
+        },
+        'expired-callback': () => {
+          quickTurnstileToken = null;
+        }
+      });
+    }
+  });
+}
+
+window.onTurnstileLibraryLoad = initializeTurnstileWidgets;
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initializeTurnstileWidgets, { once: true });
+} else {
+  initializeTurnstileWidgets();
+}
+
+function renderEstimator() {
+  activeQuestionIndex = findNextQuestionIndex();
+  renderChatLog();
+  renderPrompt();
+  renderSummary();
+  updateProgress();
+  updateSubmitAvailability();
+}
+
+function renderChatLog() {
+  if (!chatLog) return;
+  chatLog.innerHTML = '';
+  appendSystemBubble('👋 Hello! Let’s build your moving estimate together.');
+  questions.forEach(question => {
+    if (Object.prototype.hasOwnProperty.call(estimateState, question.id)) {
+      appendSystemBubble(formatPrompt(question));
+      appendUserBubble(formatAnswer(question, estimateState[question.id]));
+    }
+  });
+  if (activeQuestionIndex === -1) {
+    appendSystemBubble('That covers everything. Review your summary and press “Send to MFTNB” when you’re ready.');
+  }
+  chatLog.scrollTop = chatLog.scrollHeight;
+}
+
+function renderPrompt() {
+  if (!chatForm) return;
+  clearError();
+  const question = activeQuestionIndex === -1 ? null : questions[activeQuestionIndex];
+  if (!question) {
+    promptText.textContent = 'All set! Review the summary on the right to submit.';
+    promptHelper.textContent = '';
+    inputHolder.innerHTML = '';
+    chatSubmit.textContent = 'Next';
+    chatSubmit.disabled = true;
+    chatCompleteNote.hidden = false;
+    return;
+  }
+
+  chatCompleteNote.hidden = true;
+  promptText.textContent = formatPrompt(question);
+  promptHelper.textContent = question.helper || '';
+  buildInputForQuestion(question);
+
+  if (answeredCount() === 0 && activeQuestionIndex === 0) {
+    chatSubmit.textContent = 'Next';
+  } else if (activeQuestionIndex === questions.length - 1) {
+    chatSubmit.textContent = 'Review summary';
+  } else {
+    chatSubmit.textContent = 'Next';
+  }
+}
+
+function buildInputForQuestion(question) {
+  inputHolder.innerHTML = '';
+  activeInputElement = null;
+  let element;
+
+  if (question.type === 'multiselect') {
+    const grid = document.createElement('div');
+    grid.className = 'checkbox-grid';
+    question.options.forEach(opt => {
+      const label = document.createElement('label');
+      label.className = 'checkbox-option';
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.value = opt.value;
+      checkbox.name = question.id;
+      if (Array.isArray(estimateState[question.id]) && estimateState[question.id].includes(opt.value)) {
+        checkbox.checked = true;
+      }
+      label.appendChild(checkbox);
+      const span = document.createElement('span');
+      span.textContent = opt.label;
+      label.appendChild(span);
+      grid.appendChild(label);
+    });
+    inputHolder.appendChild(grid);
+    activeInputElement = grid;
+    chatSubmit.disabled = false;
+    return;
+  }
+
+  if (question.type === 'textarea') {
+    element = document.createElement('textarea');
+    element.className = 'input-field';
+    element.rows = 4;
+  } else if (question.type === 'select') {
+    element = document.createElement('select');
+    element.className = 'input-field';
+    question.options.forEach(opt => {
+      const option = document.createElement('option');
+      option.value = opt.value;
+      option.textContent = opt.label;
+      if (estimateState[question.id] === opt.value) {
+        option.selected = true;
+      }
+      element.appendChild(option);
+    });
+  } else if (question.type === 'date') {
+    element = document.createElement('input');
+    element.type = 'date';
+    element.className = 'input-field';
+    element.min = new Date().toISOString().split('T')[0];
+    if (estimateState[question.id]) {
+      element.value = estimateState[question.id];
+    }
+  } else {
+    element = document.createElement('input');
+    element.type = question.type === 'email' ? 'email' : (question.type === 'tel' ? 'tel' : 'text');
+    element.className = 'input-field';
+    if (estimateState[question.id]) {
+      element.value = estimateState[question.id];
+    }
+  }
+
+  element.id = `input-${question.id}`;
+  element.name = question.id;
+  if (question.placeholder) element.placeholder = question.placeholder;
+  if (question.autocomplete) element.autocomplete = question.autocomplete;
+  if (question.inputmode) element.inputMode = question.inputmode;
+  if (question.type === 'text') {
+    element.autocapitalize = 'words';
+  }
+
+  inputHolder.appendChild(element);
+  activeInputElement = element;
+  element.focus();
+
+  if (question.type === 'select') {
+    chatSubmit.disabled = question.required && !element.value;
+    element.addEventListener('change', () => {
+      chatSubmit.disabled = question.required && !element.value;
+    });
+  } else if (question.type === 'textarea' || question.type === 'text' || question.type === 'email' || question.type === 'tel' || question.type === 'date') {
+    chatSubmit.disabled = question.required && !element.value;
+    element.addEventListener('input', () => {
+      chatSubmit.disabled = question.required && !element.value;
+    });
+  }
+}
+
+function handleChatSubmit(event) {
+  event.preventDefault();
+  clearError();
+  const question = activeQuestionIndex === -1 ? null : questions[activeQuestionIndex];
+  if (!question) {
+    return;
+  }
+
+  let value;
+  if (question.type === 'multiselect') {
+    const selected = Array.from(inputHolder.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value);
+    value = selected;
+  } else if (activeInputElement) {
+    value = activeInputElement.value.trim();
+  } else {
+    value = '';
+  }
+
+  if (question.type === 'select' && activeInputElement) {
+    value = activeInputElement.value;
+  }
+
+  if (question.type === 'date' && activeInputElement) {
+    value = activeInputElement.value;
+  }
+
+  if (question.required) {
+    if (question.type === 'multiselect' && Array.isArray(value) && value.length === 0) {
+      // Allow empty selection on required multiselect because question encourages but does not force.
+      value = [];
+    }
+    if (!value || (Array.isArray(value) && value.length === 0)) {
+      setError('Please provide an answer to continue.');
+      return;
+    }
+  }
+
+  if (question.type === 'email' && value) {
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailPattern.test(value)) {
+      setError('Enter a valid email address.');
+      return;
+    }
+  }
+
+  if (question.type === 'tel' && value) {
+    const digits = value.replace(/\D/g, '');
+    if (digits.length < 7) {
+      setError('Enter a phone number with at least 7 digits.');
+      return;
+    }
+  }
+
+  if (question.type === 'multiselect') {
+    estimateState[question.id] = Array.isArray(value) ? value : [];
+  } else if (question.type === 'date') {
+    estimateState[question.id] = value;
+  } else {
+    estimateState[question.id] = value;
+  }
+
+  saveState();
+  renderEstimator();
+}
+
+function renderSummary() {
+  if (!summaryList) return;
+  summaryList.innerHTML = '';
+  summaryDefinitions.forEach(item => {
+    let value;
+    if (item.formatter) {
+      value = item.formatter(estimateState);
+    } else {
+      value = estimateState[item.id] || '';
+    }
+    if (!value) {
+      value = 'Pending—answer this in the chat.';
+    }
+    const wrapper = document.createElement('div');
+    wrapper.className = 'summary-item';
+    wrapper.setAttribute('role', 'listitem');
+    const labelEl = document.createElement('div');
+    labelEl.className = 'summary-item-label';
+    labelEl.textContent = item.label;
+    const valueEl = document.createElement('div');
+    valueEl.className = 'summary-item-value';
+    valueEl.textContent = value;
+    wrapper.appendChild(labelEl);
+    wrapper.appendChild(valueEl);
+    summaryList.appendChild(wrapper);
+  });
+}
+
+function updateProgress() {
+  if (!progressBar || !progressText) return;
+  const answered = answeredCount();
+  const totalQuestions = questions.length;
+  const totalSteps = totalQuestions + 1; // includes review
+  const progressPercent = Math.min(100, Math.round((answered / totalQuestions) * 100));
+  progressBar.style.width = `${progressPercent}%`;
+  if (answered >= totalQuestions) {
+    progressText.textContent = `Step ${totalSteps} of ${totalSteps} · Review & submit`;
+  } else {
+    progressText.textContent = `Step ${answered + 1} of ${totalSteps}`;
+  }
+}
+
+function updateSubmitAvailability() {
+  if (!sendEstimateBtn) return;
+  const answeredAll = questions.every(q => Object.prototype.hasOwnProperty.call(estimateState, q.id));
+  const ready = answeredAll && consentCheckbox && consentCheckbox.checked && !!estimateTurnstileToken && !isSubmittingEstimate;
+  sendEstimateBtn.disabled = !ready;
+}
+
+function findNextQuestionIndex() {
+  for (let i = 0; i < questions.length; i += 1) {
+    if (!Object.prototype.hasOwnProperty.call(estimateState, questions[i].id)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function answeredCount() {
+  return questions.reduce((count, question) => {
+    if (Object.prototype.hasOwnProperty.call(estimateState, question.id)) {
+      return count + 1;
+    }
+    return count;
+  }, 0);
+}
+
+function formatPrompt(question) {
+  try {
+    return typeof question.prompt === 'function' ? question.prompt(estimateState) : question.prompt;
+  } catch (err) {
+    return typeof question.prompt === 'string' ? question.prompt : 'Next question';
+  }
+}
+
+function formatAnswer(question, value) {
+  if (Array.isArray(value)) {
+    return value.length ? value.join(', ') : 'None';
+  }
+  if (question.type === 'date' && value) {
+    return formatDate(value);
+  }
+  if (!value) {
+    if (question.required) {
+      return 'Provided';
+    }
+    return 'No additional details';
+  }
+  return value;
+}
+
+function formatDate(value) {
+  const parts = value.split('-');
+  if (parts.length === 3) {
+    const [year, month, day] = parts;
+    const date = new Date(Number(year), Number(month) - 1, Number(day));
+    if (!Number.isNaN(date.getTime())) {
+      return date.toLocaleDateString('en-CA', { year: 'numeric', month: 'long', day: 'numeric' });
+    }
+  }
+  return value;
+}
+
+function appendSystemBubble(text) {
+  const bubble = document.createElement('div');
+  bubble.className = 'chat-bubble system';
+  bubble.textContent = text;
+  chatLog.appendChild(bubble);
+}
+
+function appendUserBubble(text) {
+  const bubble = document.createElement('div');
+  bubble.className = 'chat-bubble user';
+  bubble.textContent = text;
+  chatLog.appendChild(bubble);
+}
+
+function setError(message) {
+  if (!inputError) return;
+  inputError.textContent = message;
+}
+
+function clearError() {
+  if (!inputError) return;
+  inputError.textContent = '';
+}
+
+function loadState() {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) return {};
+    const parsed = JSON.parse(stored);
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+    return {};
+  } catch (err) {
+    return {};
+  }
+}
+
+function saveState() {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(estimateState));
+  } catch (err) {
+    // ignore storage errors
+  }
+}
+
+function clearStatus(el) {
+  if (!el) return;
+  el.textContent = '';
+  el.classList.remove('success', 'error');
+}
+
+function submitEstimate() {
+  if (!sendEstimateBtn || sendEstimateBtn.disabled || isSubmittingEstimate) return;
+  const payload = buildEstimatePayload();
+  if (!payload.turnstileToken) {
+    setStatus(estimateStatus, 'error', 'Please complete the Turnstile check.');
+    return;
+  }
+
+  isSubmittingEstimate = true;
+  updateSubmitAvailability();
+  sendEstimateBtn.textContent = 'Sending…';
+  sendEstimateBtn.setAttribute('aria-busy', 'true');
+  setStatus(estimateStatus, null, 'Sending your estimate securely…');
+
+  fetch(APPS_SCRIPT_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  })
+    .then(async response => {
+      const data = await safeParseJson(response);
+      if (!response.ok || !data || data.ok === false) {
+        const message = data && data.error ? data.error : 'We could not submit your estimate. Please try again.';
+        throw new Error(message);
+      }
+      return data;
+    })
+    .then(() => {
+      setStatus(estimateStatus, 'success', 'Thank you! Your estimate was sent successfully. Watch for your confirmation email shortly.');
+      estimateState = {};
+      saveState();
+      consentCheckbox.checked = false;
+      estimateTurnstileToken = null;
+      if (window.turnstile && estimateWidgetId) {
+        window.turnstile.reset(estimateWidgetId);
+      }
+      renderEstimator();
+    })
+    .catch(error => {
+      setStatus(estimateStatus, 'error', error.message || 'We could not send your estimate. Please try again or call us at (587) 731-0695.');
+    })
+    .finally(() => {
+      isSubmittingEstimate = false;
+      sendEstimateBtn.textContent = 'Send to MFTNB';
+      sendEstimateBtn.removeAttribute('aria-busy');
+      updateSubmitAvailability();
+    });
+}
+
+function buildEstimatePayload() {
+  const extras = Array.isArray(estimateState.extraServices) ? estimateState.extraServices : [];
+  return {
+    formType: 'estimate',
+    submittedAt: new Date().toISOString(),
+    name: estimateState.name || '',
+    email: estimateState.email || '',
+    phone: estimateState.phone || '',
+    pickup: estimateState.fromAddress || '',
+    dropoff: estimateState.toAddress || '',
+    moveDate: estimateState.moveDate || '',
+    timeWindow: estimateState.moveTime || '',
+    homeType: estimateState.homeType || '',
+    homeSize: estimateState.homeType || '',
+    bedrooms: estimateState.bedrooms || '',
+    access: estimateState.accessDetails || '',
+    inventory: estimateState.specialItems || '',
+    extras,
+    notes: estimateState.notes || '',
+    source: 'website-chat-estimator',
+    turnstileToken: estimateTurnstileToken,
+    consent: !!(consentCheckbox && consentCheckbox.checked)
+  };
+}
+
+function submitQuickMessage(event) {
+  event.preventDefault();
+  if (!quickForm) return;
+  const name = quickNameInput ? quickNameInput.value.trim() : '';
+  const email = quickEmailInput ? quickEmailInput.value.trim() : '';
+  const phone = quickPhoneInput ? quickPhoneInput.value.trim() : '';
+  const message = quickMessageInput ? quickMessageInput.value.trim() : '';
+
+  clearStatus(quickStatus);
+
+  if (!name) {
+    setStatus(quickStatus, 'error', 'Please add your name.');
+    return;
+  }
+  if (!message) {
+    setStatus(quickStatus, 'error', 'Let us know how we can help.');
+    return;
+  }
+  if (!email && !phone) {
+    setStatus(quickStatus, 'error', 'Add an email or phone number so we can reach you.');
+    return;
+  }
+  if (!quickTurnstileToken) {
+    setStatus(quickStatus, 'error', 'Please complete the Turnstile check.');
+    return;
+  }
+
+  const payload = {
+    formType: 'quick-message',
+    submittedAt: new Date().toISOString(),
+    name,
+    email,
+    phone,
+    message,
+    source: 'website-quick-message',
+    turnstileToken: quickTurnstileToken
+  };
+
+  setStatus(quickStatus, null, 'Sending your message…');
+
+  fetch(APPS_SCRIPT_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  })
+    .then(async response => {
+      const data = await safeParseJson(response);
+      if (!response.ok || !data || data.ok === false) {
+        const messageText = data && data.error ? data.error : 'We could not send your message. Please try again.';
+        throw new Error(messageText);
+      }
+      return data;
+    })
+    .then(() => {
+      setStatus(quickStatus, 'success', 'Thank you! We received your note and will reach out soon.');
+      quickForm.reset();
+      if (quickNameInput) quickNameInput.focus();
+      quickTurnstileToken = null;
+      if (window.turnstile && quickWidgetId) {
+        window.turnstile.reset(quickWidgetId);
+      }
+    })
+    .catch(error => {
+      setStatus(quickStatus, 'error', error.message || 'We could not send your message. Please call (587) 731-0695.');
+    });
+}
+
+function setStatus(element, state, message) {
+  if (!element) return;
+  element.textContent = message;
+  element.classList.remove('success', 'error');
+  if (state === 'success') {
+    element.classList.add('success');
+  } else if (state === 'error') {
+    element.classList.add('error');
+  }
+}
+
+function safeParseJson(response) {
+  return response.text().then(text => {
+    try {
+      return text ? JSON.parse(text) : {};
+    } catch (err) {
+      return {};
+    }
+  });
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,4 +6,10 @@
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://www.mftnb.com/privacy.html</loc>
+    <lastmod>2025-09-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,909 @@
+:root {
+  color-scheme: light;
+  --brand-navy: #142645;
+  --brand-navy-dark: #0c1a33;
+  --brand-sky: #3f7edb;
+  --brand-sky-light: #e6f0ff;
+  --brand-rose: #c64348;
+  --brand-rose-dark: #9b2c30;
+  --brand-gold: #f3c15c;
+  --surface: #f5f7fb;
+  --surface-alt: #ffffff;
+  --text-primary: #17212f;
+  --text-muted: #4f5d73;
+  --shadow-soft: 0 20px 45px rgba(20, 38, 69, 0.08);
+  --radius-lg: 28px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--surface);
+  color: var(--text-primary);
+  font-family: 'Inter', 'Segoe UI', Roboto, sans-serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: var(--brand-navy);
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 2px;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+button {
+  font-family: inherit;
+}
+
+button,
+input,
+select,
+textarea {
+  color: inherit;
+  font-size: 1rem;
+}
+
+:focus-visible {
+  outline: 3px solid var(--brand-sky);
+  outline-offset: 3px;
+}
+
+.site-header {
+  background: linear-gradient(90deg, var(--brand-navy-dark), var(--brand-navy));
+  color: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  box-shadow: 0 10px 30px rgba(12, 26, 51, 0.35);
+}
+
+.site-header .inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  gap: 1rem;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.brand img {
+  height: 48px;
+  width: auto;
+}
+
+.brand span {
+  font-weight: 600;
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+}
+
+.primary-nav {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.98rem;
+}
+
+.primary-nav a {
+  color: rgba(255, 255, 255, 0.82);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.primary-nav a:hover,
+.primary-nav a:focus {
+  color: #fff;
+}
+
+.header-cta {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-weight: 600;
+}
+
+.header-cta a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+section {
+  padding: 4.5rem 0;
+}
+
+.hero {
+  background: radial-gradient(circle at top left, rgba(63, 126, 219, 0.18), transparent 55%),
+    radial-gradient(circle at top right, rgba(198, 67, 72, 0.2), transparent 60%),
+    var(--surface);
+  padding-top: 5.5rem;
+  padding-bottom: 4.5rem;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero h1 {
+  font-size: clamp(2.5rem, 5vw, 3.6rem);
+  line-height: 1.1;
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  max-width: 580px;
+  font-size: 1.1rem;
+  color: var(--text-muted);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 2.2rem 0 1.5rem;
+}
+
+.btn-primary,
+.btn-secondary,
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.85rem 1.9rem;
+  font-size: 1rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  text-decoration: none;
+}
+
+.btn-primary {
+  background: linear-gradient(120deg, var(--brand-sky), var(--brand-rose));
+  color: #fff;
+  box-shadow: 0 15px 30px rgba(63, 126, 219, 0.3);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(63, 126, 219, 0.38);
+}
+
+.btn-secondary {
+  background: #fff;
+  color: var(--brand-navy);
+  border: 2px solid rgba(20, 38, 69, 0.12);
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+  border-color: rgba(20, 38, 69, 0.28);
+  transform: translateY(-1px);
+}
+
+.badge-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.badge {
+  background: #fff;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md);
+  box-shadow: 0 12px 25px rgba(20, 38, 69, 0.08);
+  border: 1px solid rgba(20, 38, 69, 0.05);
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.badge span {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.figure-card {
+  background: #fff;
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(20, 38, 69, 0.08);
+}
+
+.figure-card h2 {
+  margin: 0;
+  font-size: 1.85rem;
+}
+
+.section-heading {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto 2.5rem auto;
+}
+
+.section-heading h2 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin-bottom: 0.75rem;
+}
+
+.section-heading p {
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.grid-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  border: 1px solid rgba(20, 38, 69, 0.08);
+  box-shadow: 0 15px 30px rgba(20, 38, 69, 0.05);
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.highlight {
+  background: linear-gradient(135deg, rgba(63, 126, 219, 0.12), rgba(198, 67, 72, 0.12));
+  border-radius: var(--radius-lg);
+  padding: 3rem 2.25rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.highlight h3 {
+  margin-top: 0;
+  font-size: 2rem;
+}
+
+.highlight p {
+  font-size: 1.05rem;
+  color: var(--text-muted);
+}
+
+.estimator-section {
+  background: #f9fbff;
+}
+
+.estimator-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(280px, 1fr);
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.chat-shell {
+  background: #fff;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(20, 38, 69, 0.08);
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.chat-log {
+  padding: 1.75rem;
+  overflow-y: auto;
+  max-height: clamp(360px, 55dvh, 640px);
+  scroll-behavior: smooth;
+}
+
+.chat-log::-webkit-scrollbar {
+  width: 10px;
+}
+
+.chat-log::-webkit-scrollbar-thumb {
+  background: rgba(20, 38, 69, 0.25);
+  border-radius: 999px;
+}
+
+.chat-bubble {
+  max-width: 85%;
+  padding: 0.95rem 1.2rem;
+  border-radius: 20px;
+  margin-bottom: 1rem;
+  word-break: break-word;
+  font-size: 0.98rem;
+  line-height: 1.5;
+}
+
+.chat-bubble.system {
+  background: rgba(63, 126, 219, 0.12);
+  color: var(--brand-navy);
+  border-radius: 20px 20px 20px 6px;
+}
+
+.chat-bubble.user {
+  margin-left: auto;
+  background: linear-gradient(135deg, var(--brand-navy), var(--brand-sky));
+  color: #fff;
+  border-radius: 20px 20px 6px 20px;
+}
+
+.chat-composer {
+  border-top: 1px solid rgba(20, 38, 69, 0.08);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: rgba(249, 251, 255, 0.8);
+}
+
+.composer-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+#promptText {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+#promptHelper {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--text-muted);
+}
+
+.input-field,
+textarea.input-field {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(20, 38, 69, 0.22);
+  padding: 0.85rem 1rem;
+  background: #fff;
+  font-size: 1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+textarea.input-field {
+  min-height: 110px;
+  resize: vertical;
+}
+
+.input-field:focus {
+  border-color: var(--brand-sky);
+  box-shadow: 0 0 0 3px rgba(63, 126, 219, 0.15);
+}
+
+.checkbox-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.checkbox-option {
+  background: #fff;
+  border: 1px solid rgba(20, 38, 69, 0.18);
+  border-radius: 14px;
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  font-size: 0.95rem;
+}
+
+.checkbox-option input {
+  margin-top: 0.2rem;
+}
+
+.composer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+#inputError {
+  color: var(--brand-rose);
+  font-size: 0.9rem;
+  min-height: 1.2rem;
+}
+
+.chat-complete-note {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.summary-panel {
+  background: #fff;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(20, 38, 69, 0.08);
+  padding: 1.75rem;
+  position: sticky;
+  top: 96px;
+}
+
+.summary-panel h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
+.progress-wrap {
+  margin-bottom: 1.25rem;
+}
+
+.progress-bar {
+  height: 10px;
+  background: rgba(20, 38, 69, 0.1);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-bar span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(135deg, var(--brand-sky), var(--brand-rose));
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+#progressText {
+  margin-top: 0.4rem;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.summary-list {
+  margin: 1.25rem 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.summary-item {
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid rgba(20, 38, 69, 0.08);
+}
+
+.summary-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.summary-item-label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.summary-item-value {
+  margin: 0;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+}
+
+.notice {
+  background: rgba(63, 126, 219, 0.1);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  font-size: 0.9rem;
+  color: var(--brand-navy);
+}
+
+.checkbox-consent {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  font-size: 0.95rem;
+  margin: 1.25rem 0 0.85rem;
+}
+
+.checkbox-consent input {
+  margin-top: 0.25rem;
+}
+
+.action-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.btn-submit {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(120deg, var(--brand-rose), var(--brand-navy));
+  color: #fff;
+  border: none;
+  font-size: 1.05rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-submit:hover,
+.btn-submit:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 25px rgba(20, 38, 69, 0.25);
+}
+
+.btn-submit[disabled] {
+  background: rgba(20, 38, 69, 0.18);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn-link {
+  background: none;
+  border: none;
+  color: var(--brand-navy);
+  font-weight: 600;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+  align-self: flex-start;
+}
+
+.status-message {
+  min-height: 1.2rem;
+  font-size: 0.92rem;
+}
+
+.status-message.success {
+  color: #1f7a3d;
+}
+
+.status-message.error {
+  color: var(--brand-rose);
+}
+
+.steps-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.step-card {
+  background: #fff;
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  border: 1px solid rgba(20, 38, 69, 0.08);
+  box-shadow: 0 12px 24px rgba(20, 38, 69, 0.05);
+}
+
+.step-number {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--brand-sky), var(--brand-rose));
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.testimonial-wrap {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.testimonial {
+  background: #fff;
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+  border: 1px solid rgba(20, 38, 69, 0.08);
+  box-shadow: 0 18px 32px rgba(20, 38, 69, 0.06);
+  position: relative;
+}
+
+.testimonial::before {
+  content: '“';
+  font-size: 4rem;
+  position: absolute;
+  top: -10px;
+  left: 20px;
+  color: rgba(198, 67, 72, 0.25);
+  font-family: 'Georgia', serif;
+}
+
+.testimonial p {
+  margin: 0 0 1.5rem 0;
+  color: var(--text-muted);
+  font-size: 0.98rem;
+}
+
+.testimonial span {
+  font-weight: 600;
+  color: var(--brand-navy);
+}
+
+.reviews-embed {
+  margin-top: 2rem;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(20, 38, 69, 0.12);
+  border: 1px solid rgba(20, 38, 69, 0.08);
+}
+
+.faq-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.faq-card {
+  background: #fff;
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  border: 1px solid rgba(20, 38, 69, 0.08);
+  box-shadow: 0 12px 24px rgba(20, 38, 69, 0.05);
+}
+
+.faq-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+  align-items: start;
+}
+
+.contact-card {
+  background: #fff;
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(20, 38, 69, 0.08);
+}
+
+.contact-card h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.contact-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1.5rem 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.contact-list li span {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+}
+
+.quick-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.quick-form label {
+  font-weight: 600;
+}
+
+.quick-form input,
+.quick-form textarea {
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(20, 38, 69, 0.22);
+  padding: 0.75rem 0.9rem;
+  font-size: 1rem;
+  background: #fff;
+}
+
+.quick-form textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.quick-form button {
+  justify-self: start;
+  padding-inline: 1.6rem;
+}
+
+#quickStatus {
+  font-size: 0.92rem;
+  min-height: 1.2rem;
+}
+
+#quickStatus.success {
+  color: #1f7a3d;
+}
+
+#quickStatus.error {
+  color: var(--brand-rose);
+}
+
+.site-footer {
+  background: var(--brand-navy-dark);
+  color: rgba(255, 255, 255, 0.82);
+  padding: 2.5rem 0 2rem;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2rem;
+}
+
+.site-footer h4 {
+  color: #fff;
+  margin-top: 0;
+}
+
+.footer-nav,
+.footer-contact {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.footer-nav a,
+.footer-contact a {
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+}
+
+.footer-nav a:hover,
+.footer-contact a:hover,
+.footer-nav a:focus,
+.footer-contact a:focus {
+  text-decoration: underline;
+}
+
+.footer-bottom {
+  margin-top: 2rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
+  padding-top: 1rem;
+  font-size: 0.9rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.hero-visual {
+  position: relative;
+}
+
+.hero-visual::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(63, 126, 219, 0.15), rgba(198, 67, 72, 0.18));
+  filter: blur(45px);
+  z-index: 0;
+}
+
+.hero-card {
+  position: relative;
+  z-index: 1;
+  background: #fff;
+  border-radius: var(--radius-lg);
+  padding: 2.25rem;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(20, 38, 69, 0.08);
+}
+
+.hero-card h3 {
+  margin-top: 0;
+}
+
+.hero-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0 0;
+  display: grid;
+  gap: 0.6rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 960px) {
+  .primary-nav {
+    display: none;
+  }
+  .hero-grid {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+  .hero-actions {
+    justify-content: center;
+  }
+  .hero-card {
+    margin: 0 auto;
+  }
+  .summary-panel {
+    position: static;
+  }
+  .estimator-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .site-header .inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+  .header-cta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
+  section {
+    padding: 3.5rem 0;
+  }
+  .chat-log {
+    max-height: min(60dvh, 520px);
+  }
+  .chat-composer {
+    padding-bottom: max(1.5rem, env(safe-area-inset-bottom, 1.5rem));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the homepage into an accessible, multi-section layout with hero messaging, services, testimonials, estimator, FAQ, and contact panels tailored to seniors and community storytelling
- extract styling into a dedicated stylesheet and implement a modular chat-style estimator script that saves progress locally, enforces validation, renders summaries, and integrates Cloudflare Turnstile for both the estimate flow and quick-message form
- add a standalone privacy policy page plus sitemap entry, and overhaul the Google Apps Script backend to verify Turnstile tokens, write leads/quick messages to separate sheets, and deliver confirmation emails to both the office and submitters

## Testing
- not run (static site / Apps Script changes)


------
https://chatgpt.com/codex/tasks/task_e_68d0be589468832f90cfe7f50f5fca40