### PR TITLE
Handle Turnstile library load delays

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
   <link rel="shortcut icon" href="favicon.ico" />
   <meta name="theme-color" content="#142645" />
-  <script defer src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onTurnstileLibraryLoad" async></script>
+  <script defer src="https://challenges.cloudflare.com/turnstile/v0/api.js" async></script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- stop requiring the Turnstile API to call a pre-defined onload callback
- add retry logic so initializeTurnstileWidgets waits for the library before rendering widgets

## Testing
- `node - <<'JS'` (Turnstile stub simulation)


------
https://chatgpt.com/codex/tasks/task_e_68d0d9cb8e68832f802067f3d6ca7c2e