### PR TITLE
Fix estimate payload home size to use bedrooms

### DIFF
--- a/script.js
+++ b/script.js
@@ -753,7 +753,7 @@ function buildEstimatePayload() {
     moveDate: estimateState.moveDate || '',
     timeWindow: estimateState.moveTime || '',
     homeType: estimateState.homeType || '',
-    homeSize: estimateState.homeType || '',
+    homeSize: estimateState.bedrooms || '',
     bedrooms: estimateState.bedrooms || '',
     access: estimateState.accessDetails || '',
     inventory: estimateState.specialItems || '',


### PR DESCRIPTION
## Summary
- update the estimator payload so `homeSize` uses the selected bedroom count instead of duplicating `homeType`
- ensure the Apps Script receives both the home type and bedroom count when logging `body.homeType || body.homeSize`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0d416dc58832f88b47cf83dec14ab