### PR TITLE
Fix Cloudflare Turnstile initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -281,7 +281,9 @@ if (quickForm) {
 }
 
 function initializeTurnstileWidgets() {
-  if (!window.turnstile) {
+  const turnstileApi = window.turnstile;
+
+  if (!turnstileApi || typeof turnstileApi.render !== 'function') {
     if (!turnstileRetryHandle) {
       turnstileRetryHandle = window.setTimeout(() => {
         turnstileRetryHandle = null;
@@ -296,45 +298,43 @@ function initializeTurnstileWidgets() {
     turnstileRetryHandle = null;
   }
 
-  window.turnstile.ready(() => {
-    if (document.getElementById('estimateTurnstile') && !estimateWidgetId) {
-      estimateWidgetId = window.turnstile.render('#estimateTurnstile', {
-        sitekey: TURNSTILE_SITE_KEY,
-        action: 'estimate',
-        theme: 'light',
-        callback: token => {
-          estimateTurnstileToken = token;
-          updateSubmitAvailability();
-        },
-        'error-callback': () => {
-          estimateTurnstileToken = null;
-          updateSubmitAvailability();
-        },
-        'expired-callback': () => {
-          estimateTurnstileToken = null;
-          updateSubmitAvailability();
-        }
-      });
-    }
+  if (document.getElementById('estimateTurnstile') && !estimateWidgetId) {
+    estimateWidgetId = turnstileApi.render('#estimateTurnstile', {
+      sitekey: TURNSTILE_SITE_KEY,
+      action: 'estimate',
+      theme: 'light',
+      callback: token => {
+        estimateTurnstileToken = token;
+        updateSubmitAvailability();
+      },
+      'error-callback': () => {
+        estimateTurnstileToken = null;
+        updateSubmitAvailability();
+      },
+      'expired-callback': () => {
+        estimateTurnstileToken = null;
+        updateSubmitAvailability();
+      }
+    });
+  }
 
-    if (document.getElementById('quickTurnstile') && !quickWidgetId) {
-      quickWidgetId = window.turnstile.render('#quickTurnstile', {
-        sitekey: TURNSTILE_SITE_KEY,
-        action: 'quick_message',
-        theme: 'light',
-        size: 'compact',
-        callback: token => {
-          quickTurnstileToken = token;
-        },
-        'error-callback': () => {
-          quickTurnstileToken = null;
-        },
-        'expired-callback': () => {
-          quickTurnstileToken = null;
-        }
-      });
-    }
-  });
+  if (document.getElementById('quickTurnstile') && !quickWidgetId) {
+    quickWidgetId = turnstileApi.render('#quickTurnstile', {
+      sitekey: TURNSTILE_SITE_KEY,
+      action: 'quick_message',
+      theme: 'light',
+      size: 'compact',
+      callback: token => {
+        quickTurnstileToken = token;
+      },
+      'error-callback': () => {
+        quickTurnstileToken = null;
+      },
+      'expired-callback': () => {
+        quickTurnstileToken = null;
+      }
+    });
+  }
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- stop calling `turnstile.ready` while the API script is loaded with `async/defer`, and instead render widgets once the Turnstile API exposes `render`
- retain the retry loop so the widgets still initialize after slow loads and continue updating tokens on callbacks

## Testing
- Started a local static server and exercised the estimator; Turnstile now renders without the `turnstile.ready` runtime error (Cloudflare returns 400s on 127.0.0.1 due to site-key restrictions).


------
https://chatgpt.com/codex/tasks/task_e_68d0f1a993c8832fbe2c0ac35f1297bf