### PR TITLE
Improve Turnstile secret configuration and diagnostics

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -16,9 +16,16 @@ Option B: Cloudflare Pages
 Set up the backend (Google Apps Script → Google Sheets)
 1) Drive → New → Google Sheet (e.g., “MFTNB Leads”), keep Sheet1.
 2) Extensions → Apps Script → paste contents of apps_script.gs.
-3) File → Save. Deploy → New deployment → Web app → Execute as: Me; Access: Anyone (or Anyone with the link). Copy URL.
-4) Open index.html and set BACKEND.appsScriptUrl to that URL. Save and redeploy your site.
-5) Submit a test; a new row appears in the sheet and an email is sent (optional).
+3) File → Save. In Project Settings → Script properties, add `TURNSTILE_SECRET` with your Cloudflare secret key. (Never store the secret in source control.)
+4) Deploy → New deployment → Web app → Execute as: Me; Access: Anyone (or Anyone with the link). Copy URL.
+5) Open script.js and set `APPS_SCRIPT_URL` to that URL. Save and redeploy your site.
+6) Submit a test; a new row appears in the sheet and an email is sent (optional).
+
+Cloudflare Turnstile configuration
+- Frontend: The estimator and quick message forms render Turnstile explicitly. Update `TURNSTILE_SITE_KEY` in `script.js` with your site key from the Cloudflare dashboard.
+- The widget is loaded via `https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit`. If the script is blocked, the UI now surfaces a clear message so visitors know to refresh or allow the challenge.
+- Backend: Store the secret key in the `TURNSTILE_SECRET` script property. (Keep `TURNSTILE_SECRET_FALLBACK` blank unless you are doing a one-off local test.) The Apps Script verifies every submission with Cloudflare before anything is written to Sheets.
+- Rotate keys in the Cloudflare dashboard as needed; only update Script Properties and the site key constant—no repository changes are required when swapping secrets.
 
 Privacy & anti-spam
 - No secrets or keys in the frontend. Apps Script runs server-side in your Google account.

--- a/apps_script.gs
+++ b/apps_script.gs
@@ -5,7 +5,27 @@ const ESTIMATE_SHEET_NAME = 'Leads';
 const QUICK_SHEET_NAME = 'Quick Messages';
 const OFFICE_EMAIL = 'info@mftnb.ca';
 const CUSTOMER_SUBJECT = 'We received your message – Moving Forward to New Beginnings';
-const TURNSTILE_SECRET = '0x4AAAAAAB2gwLfn0PN8o6zw4eLmMN0r49g';
+const SCRIPT_PROPERTIES = PropertiesService.getScriptProperties();
+const TURNSTILE_SECRET_PROPERTY = 'TURNSTILE_SECRET';
+// Optional: populate TURNSTILE_SECRET_FALLBACK for temporary testing only. Prefer Script Properties.
+const TURNSTILE_SECRET_FALLBACK = '';
+
+function getTurnstileSecret() {
+  const propertySecret = SCRIPT_PROPERTIES.getProperty(TURNSTILE_SECRET_PROPERTY);
+  if (propertySecret) {
+    const trimmedProperty = propertySecret.trim();
+    if (trimmedProperty) {
+      return trimmedProperty;
+    }
+  }
+  if (TURNSTILE_SECRET_FALLBACK) {
+    const trimmedFallback = String(TURNSTILE_SECRET_FALLBACK).trim();
+    if (trimmedFallback) {
+      return trimmedFallback;
+    }
+  }
+  return '';
+}
 
 function doOptions() {
   return respond({ ok: true }, 200);
@@ -26,8 +46,22 @@ function doPost(e) {
     const token = body.turnstileToken;
     const expectedAction = formType === 'estimate' ? 'estimate' : (formType === 'quick-message' ? 'quick_message' : '');
     const verification = verifyTurnstile(token, e, expectedAction);
+    if (verification.configError) {
+      return respond({
+        ok: false,
+        error: 'Verification service unavailable.',
+        detail: verification.error || null
+      }, 500);
+    }
     if (!verification.success) {
-      return respond({ ok: false, error: 'Human verification failed.' }, 400);
+      const failBody = { ok: false, error: 'Human verification failed.' };
+      if (verification.error) {
+        failBody.detail = verification.error;
+      }
+      if (verification.errorCodes && verification.errorCodes.length) {
+        failBody.errorCodes = verification.errorCodes;
+      }
+      return respond(failBody, 400);
     }
 
     if (formType === 'estimate') {
@@ -49,11 +83,12 @@ function doPost(e) {
 
 function handleEstimateSubmission(body) {
   const requiredFields = ['name', 'email', 'phone', 'pickup', 'dropoff'];
-  requiredFields.forEach(field => {
+  for (var i = 0; i < requiredFields.length; i++) {
+    var field = requiredFields[i];
     if (!body[field]) {
       throw new Error('Missing required field: ' + field);
     }
-  });
+  }
 
   const sheet = getOrCreateSheet(ESTIMATE_SHEET_NAME);
   const timestamp = new Date();
@@ -80,10 +115,17 @@ function handleEstimateSubmission(body) {
   const rowNumber = sheet.getLastRow();
 
   const officeHtml = buildEstimateHtml(body, timestamp, rowNumber);
+  var officeSubjectName = body.name ? String(body.name) : '';
+  if (officeSubjectName) {
+    officeSubjectName = officeSubjectName.trim();
+  }
+  if (!officeSubjectName) {
+    officeSubjectName = 'Unknown contact';
+  }
   try {
     MailApp.sendEmail({
       to: OFFICE_EMAIL,
-      subject: `New moving estimate from ${body.name}`,
+      subject: 'New moving estimate from ' + officeSubjectName,
       htmlBody: officeHtml
     });
   } catch (err) {
@@ -104,7 +146,7 @@ function handleEstimateSubmission(body) {
     }
   }
 
-  return { rowNumber };
+  return { rowNumber: rowNumber };
 }
 
 function handleQuickMessageSubmission(body) {
@@ -122,20 +164,29 @@ function handleQuickMessageSubmission(body) {
     body.source || ''
   ]);
 
-  const officeBody = `
-    <p><strong>New quick message received:</strong></p>
-    <ul>
-      <li><strong>Name:</strong> ${sanitize(body.name)}</li>
-      <li><strong>Email:</strong> ${sanitize(body.email || 'N/A')}</li>
-      <li><strong>Phone:</strong> ${sanitize(body.phone || 'N/A')}</li>
-      <li><strong>Message:</strong><br />${sanitize(body.message).replace(/\n/g, '<br />')}</li>
-    </ul>
-  `;
+  const sanitizedMessage = sanitize(body.message).replace(/\n/g, '<br />');
+  const officeBodyLines = [
+    '<p><strong>New quick message received:</strong></p>',
+    '<ul>',
+    '  <li><strong>Name:</strong> ' + sanitize(body.name) + '</li>',
+    '  <li><strong>Email:</strong> ' + sanitize(body.email || 'N/A') + '</li>',
+    '  <li><strong>Phone:</strong> ' + sanitize(body.phone || 'N/A') + '</li>',
+    '  <li><strong>Message:</strong><br />' + sanitizedMessage + '</li>',
+    '</ul>'
+  ];
+  const officeBody = officeBodyLines.join('\n');
+  var quickSubjectName = body.name ? String(body.name) : '';
+  if (quickSubjectName) {
+    quickSubjectName = quickSubjectName.trim();
+  }
+  if (!quickSubjectName) {
+    quickSubjectName = 'Unknown contact';
+  }
 
   try {
     MailApp.sendEmail({
       to: OFFICE_EMAIL,
-      subject: `Quick message from ${body.name}`,
+      subject: 'Quick message from ' + quickSubjectName,
       htmlBody: officeBody
     });
   } catch (err) {
@@ -143,13 +194,14 @@ function handleQuickMessageSubmission(body) {
   }
 
   if (body.email) {
-    const customerBody = `
-      <p>Hi ${sanitize(body.name)},</p>
-      <p>Thanks for getting in touch with Moving Forward to New Beginnings. We received your note and will reply shortly.</p>
-      <p><strong>Your message:</strong><br />${sanitize(body.message).replace(/\n/g, '<br />')}</p>
-      <p>If anything changes, call or text us at <a href="tel:+15877310695">(587) 731-0695</a>.</p>
-      <p>— Chris Ehret &amp; the MFTNB team</p>
-    `;
+    const customerBodyLines = [
+      '<p>Hi ' + sanitize(body.name) + ',</p>',
+      '<p>Thanks for getting in touch with Moving Forward to New Beginnings. We received your note and will reply shortly.</p>',
+      '<p><strong>Your message:</strong><br />' + sanitizedMessage + '</p>',
+      '<p>If anything changes, call or text us at <a href="tel:+15877310695">(587) 731-0695</a>.</p>',
+      '<p>— Chris Ehret &amp; the MFTNB team</p>'
+    ];
+    const customerBody = customerBodyLines.join('\n');
     try {
       MailApp.sendEmail({
         to: body.email,
@@ -165,77 +217,120 @@ function handleQuickMessageSubmission(body) {
 
 function verifyTurnstile(token, e, expectedAction) {
   if (!token) {
-    return { success: false };
+    return { success: false, error: 'missing-token' };
   }
+
+  const secret = getTurnstileSecret();
+  if (!secret) {
+    console.error('Turnstile secret is not configured. Set TURNSTILE_SECRET in Script Properties.');
+    return { success: false, configError: true, error: 'missing-secret' };
+  }
+
   const remoteip = e && e.context ? e.context.clientIp : '';
   const payload = {
-    secret: TURNSTILE_SECRET,
+    secret: secret,
     response: token
   };
   if (remoteip) {
     payload.remoteip = remoteip;
   }
-  const response = UrlFetchApp.fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
-    method: 'post',
-    payload,
-    muteHttpExceptions: true
-  });
-  const data = JSON.parse(response.getContentText() || '{}');
+
+  let response;
+  try {
+    response = UrlFetchApp.fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'post',
+      payload,
+      muteHttpExceptions: true
+    });
+  } catch (err) {
+    console.error('Turnstile verification request failed', err);
+    return { success: false, error: 'fetch-error' };
+  }
+
+  let data;
+  try {
+    data = JSON.parse(response.getContentText() || '{}');
+  } catch (err) {
+    console.error('Unable to parse Turnstile response', err);
+    return { success: false, error: 'parse-error' };
+  }
+
+  const status = typeof response.getResponseCode === 'function' ? response.getResponseCode() : 0;
+  if (status && status !== 200) {
+    console.error('Turnstile verification returned status', status, data);
+  }
+
   if (!data.success) {
     console.error('Turnstile verification failed', data['error-codes']);
-    return { success: false };
+    return {
+      success: false,
+      error: 'turnstile-failed',
+      errorCodes: Array.isArray(data['error-codes']) ? data['error-codes'] : []
+    };
   }
+
   if (expectedAction && data.action && data.action !== expectedAction) {
     console.warn('Unexpected Turnstile action', data.action, 'expected', expectedAction);
   }
+
   return data;
 }
 
 function buildEstimateHtml(body, timestamp, rowNumber) {
   const extras = Array.isArray(body.extras) && body.extras.length ? body.extras.join(', ') : 'None';
-  return `
-    <h2>New moving estimate (row ${rowNumber})</h2>
-    <p><strong>Received:</strong> ${timestamp}</p>
-    <table border="0" cellpadding="6" cellspacing="0" style="border-collapse:collapse;">
-      <tbody>
-        <tr><td><strong>Name</strong></td><td>${sanitize(body.name)}</td></tr>
-        <tr><td><strong>Email</strong></td><td>${sanitize(body.email)}</td></tr>
-        <tr><td><strong>Phone</strong></td><td>${sanitize(body.phone)}</td></tr>
-        <tr><td><strong>Moving from</strong></td><td>${sanitize(body.pickup)}</td></tr>
-        <tr><td><strong>Moving to</strong></td><td>${sanitize(body.dropoff)}</td></tr>
-        <tr><td><strong>Move date</strong></td><td>${sanitize(body.moveDate || 'Flexible')}</td></tr>
-        <tr><td><strong>Preferred time</strong></td><td>${sanitize(body.timeWindow || 'Flexible')}</td></tr>
-        <tr><td><strong>Home type</strong></td><td>${sanitize(body.homeType || body.homeSize || '')}</td></tr>
-        <tr><td><strong>Bedrooms</strong></td><td>${sanitize(body.bedrooms || '')}</td></tr>
-        <tr><td><strong>Access details</strong></td><td>${sanitize(body.access || '')}</td></tr>
-        <tr><td><strong>Special items</strong></td><td>${sanitize(body.inventory || '')}</td></tr>
-        <tr><td><strong>Extras</strong></td><td>${sanitize(extras)}</td></tr>
-        <tr><td><strong>Notes</strong></td><td>${sanitize(body.notes || '')}</td></tr>
-        <tr><td><strong>Source</strong></td><td>${sanitize(body.source || '')}</td></tr>
-      </tbody>
-    </table>
-  `;
+  const lines = [];
+  lines.push('<h2>New moving estimate (row ' + rowNumber + ')</h2>');
+  lines.push('<p><strong>Received:</strong> ' + timestamp + '</p>');
+  lines.push('<table border="0" cellpadding="6" cellspacing="0" style="border-collapse:collapse;">');
+  lines.push('  <tbody>');
+  lines.push('    <tr><td><strong>Name</strong></td><td>' + sanitize(body.name) + '</td></tr>');
+  lines.push('    <tr><td><strong>Email</strong></td><td>' + sanitize(body.email) + '</td></tr>');
+  lines.push('    <tr><td><strong>Phone</strong></td><td>' + sanitize(body.phone) + '</td></tr>');
+  lines.push('    <tr><td><strong>Moving from</strong></td><td>' + sanitize(body.pickup) + '</td></tr>');
+  lines.push('    <tr><td><strong>Moving to</strong></td><td>' + sanitize(body.dropoff) + '</td></tr>');
+  lines.push('    <tr><td><strong>Move date</strong></td><td>' + sanitize(body.moveDate || 'Flexible') + '</td></tr>');
+  lines.push('    <tr><td><strong>Preferred time</strong></td><td>' + sanitize(body.timeWindow || 'Flexible') + '</td></tr>');
+  lines.push('    <tr><td><strong>Home type</strong></td><td>' + sanitize(body.homeType || body.homeSize || '') + '</td></tr>');
+  lines.push('    <tr><td><strong>Bedrooms</strong></td><td>' + sanitize(body.bedrooms || '') + '</td></tr>');
+  lines.push('    <tr><td><strong>Access details</strong></td><td>' + sanitize(body.access || '') + '</td></tr>');
+  lines.push('    <tr><td><strong>Special items</strong></td><td>' + sanitize(body.inventory || '') + '</td></tr>');
+  lines.push('    <tr><td><strong>Extras</strong></td><td>' + sanitize(extras) + '</td></tr>');
+  lines.push('    <tr><td><strong>Notes</strong></td><td>' + sanitize(body.notes || '') + '</td></tr>');
+  lines.push('    <tr><td><strong>Source</strong></td><td>' + sanitize(body.source || '') + '</td></tr>');
+  lines.push('  </tbody>');
+  lines.push('</table>');
+  return lines.join('\n');
 }
 
 function buildCustomerEstimateHtml(body, timestamp) {
   const extras = Array.isArray(body.extras) && body.extras.length ? body.extras.join(', ') : 'None';
-  return `
-    <p>Hi ${sanitize(body.name)},</p>
-    <p>Thank you for reaching out to Moving Forward to New Beginnings. We received your moving details on <strong>${timestamp.toLocaleString()}</strong> and will follow up shortly with next steps.</p>
-    <h3>Your summary</h3>
-    <ul>
-      <li><strong>Move date:</strong> ${sanitize(body.moveDate || 'Flexible')}</li>
-      <li><strong>From:</strong> ${sanitize(body.pickup)}</li>
-      <li><strong>To:</strong> ${sanitize(body.dropoff)}</li>
-      <li><strong>Home type &amp; rooms:</strong> ${sanitize([body.homeType || body.homeSize || '', body.bedrooms || ''].filter(Boolean).join(' · ') || 'Details pending')}</li>
-      <li><strong>Access details:</strong> ${sanitize(body.access || 'Provided verbally')}</li>
-      <li><strong>Special items:</strong> ${sanitize(body.inventory || 'None noted')}</li>
-      <li><strong>Extra services:</strong> ${sanitize(extras)}</li>
-      <li><strong>Additional notes:</strong> ${sanitize(body.notes || 'None')}</li>
-    </ul>
-    <p>If anything changes, reply to this email or call/text <a href="tel:+15877310695">(587) 731-0695</a>.</p>
-    <p>With gratitude,<br />Chris Ehret &amp; the MFTNB team</p>
-  `;
+  const summaryParts = [];
+  if (body.homeType || body.homeSize) {
+    summaryParts.push(body.homeType || body.homeSize);
+  }
+  if (body.bedrooms) {
+    summaryParts.push(body.bedrooms);
+  }
+  const homeSummary = summaryParts.filter(function(part) {
+    return part;
+  }).join(' · ') || 'Details pending';
+  const lines = [];
+  lines.push('<p>Hi ' + sanitize(body.name) + ',</p>');
+  lines.push('<p>Thank you for reaching out to Moving Forward to New Beginnings. We received your moving details on <strong>' + timestamp.toLocaleString() + '</strong> and will follow up shortly with next steps.</p>');
+  lines.push('<h3>Your summary</h3>');
+  lines.push('<ul>');
+  lines.push('  <li><strong>Move date:</strong> ' + sanitize(body.moveDate || 'Flexible') + '</li>');
+  lines.push('  <li><strong>From:</strong> ' + sanitize(body.pickup) + '</li>');
+  lines.push('  <li><strong>To:</strong> ' + sanitize(body.dropoff) + '</li>');
+  lines.push('  <li><strong>Home type &amp; rooms:</strong> ' + sanitize(homeSummary) + '</li>');
+  lines.push('  <li><strong>Access details:</strong> ' + sanitize(body.access || 'Provided verbally') + '</li>');
+  lines.push('  <li><strong>Special items:</strong> ' + sanitize(body.inventory || 'None noted') + '</li>');
+  lines.push('  <li><strong>Extra services:</strong> ' + sanitize(extras) + '</li>');
+  lines.push('  <li><strong>Additional notes:</strong> ' + sanitize(body.notes || 'None') + '</li>');
+  lines.push('</ul>');
+  lines.push('<p>If anything changes, reply to this email or call/text <a href="tel:+15877310695">(587) 731-0695</a>.</p>');
+  lines.push('<p>With gratitude,<br />Chris Ehret &amp; the MFTNB team</p>');
+  return lines.join('\n');
 }
 
 function getOrCreateSheet(name) {
@@ -259,12 +354,18 @@ function sanitize(value) {
 
 function respond(obj, code) {
   const output = ContentService.createTextOutput(JSON.stringify(obj)).setMimeType(ContentService.MimeType.JSON);
-  output.setHeaders({
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'POST, OPTIONS, GET',
-    'Access-Control-Allow-Headers': 'Content-Type'
-  });
-  if (typeof code === 'number') {
+  if (typeof output.setHeaders === 'function') {
+    output.setHeaders({
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS, GET',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    });
+  } else if (typeof output.setHeader === 'function') {
+    output.setHeader('Access-Control-Allow-Origin', '*');
+    output.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS, GET');
+    output.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  }
+  if (typeof code === 'number' && typeof output.setResponseCode === 'function') {
     output.setResponseCode(code);
   }
   return output;

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
   <link rel="shortcut icon" href="favicon.ico" />
   <meta name="theme-color" content="#142645" />
-  <script defer src="https://challenges.cloudflare.com/turnstile/v0/api.js" async></script>
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" async defer></script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- add a documented Turnstile secret fallback hook while still preferring the Script Property value
- return detailed Turnstile error information so failed submissions surface actionable causes
- clarify the README instructions around keeping the fallback blank unless doing temporary testing

## Testing
- node -e "new Function(require('fs').readFileSync('apps_script.gs','utf8'))"
- node -e "new Function(require('fs').readFileSync('script.js','utf8'))"


------
https://chatgpt.com/codex/tasks/task_e_68d185b55da4832f83cfdd9880a9b144