### PR TITLE
Use simple request headers for form submissions

### DIFF
--- a/script.js
+++ b/script.js
@@ -788,7 +788,7 @@ function submitEstimate() {
 
   fetch(APPS_SCRIPT_URL, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
     body: JSON.stringify(payload)
   })
     .then(async response => {
@@ -888,7 +888,7 @@ function submitQuickMessage(event) {
 
   fetch(APPS_SCRIPT_URL, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
     body: JSON.stringify(payload)
   })
     .then(async response => {


### PR DESCRIPTION
## Summary
- adjust both estimate and quick message fetch calls to use text/plain simple request headers while keeping JSON payloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d19cef84e4832f953f100e27319980